### PR TITLE
Fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
         additional_dependencies: ['flake8-bugbear']
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.12.0
+    # Latest available tag in mirrors-isort repository
+    # v5.12.0 does not exist which breaks pre-commit installation
+    rev: v5.10.1
     hooks:
       - id: isort
         name: isort


### PR DESCRIPTION
## Summary
- pin `mirrors-isort` repo to valid tag

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683f52cf5bc8832286c4f3bcb4297289