### PR TITLE
Fix ApiService scope and widget test import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
         additional_dependencies: ['flake8-bugbear']
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.12.0
+    # Latest available tag in mirrors-isort repository
+    # v5.12.0 does not exist which breaks pre-commit installation
+    rev: v5.10.1
     hooks:
       - id: isort
         name: isort

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -27,7 +27,6 @@ class ApiService {
     );
     return response.data;
   }
-}
 
   Future<Map<String, dynamic>> getDashboard() async {
     final token = await getToken();
@@ -146,8 +145,6 @@ class ApiService {
     );
   }
 
-}
-
   Future<Map<String, dynamic>> getUserProfile() async {
     final token = await getToken();
     final response = await _dio.get(
@@ -221,3 +218,4 @@ class ApiService {
     );
     return response.data;
   }
+}

--- a/mobile_app/test/widget_test.dart
+++ b/mobile_app/test/widget_test.dart
@@ -8,12 +8,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:mobile_app/main.dart';
+import 'package:mita/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const MITAApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- keep ApiService methods inside the class by removing an extra `}`
- import `MITAApp` using the correct package name in the widget test

## Testing
- `pre-commit run --files mobile_app/lib/services/api_service.dart mobile_app/test/widget_test.dart .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f52cf5bc8832286c4f3bcb4297289