### PR TITLE
Fix onboarding and IAP stubs

### DIFF
--- a/app/api/iap.py
+++ b/app/api/iap.py
@@ -1,23 +1,44 @@
-from app.utils.response_wrapper import success_response
+from datetime import datetime, timedelta
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
+from app.api.iap.services import validate_receipt
 from app.core.session import get_db
 from app.db.models import Subscription
-from app.api.dependencies import get_current_user
+from app.utils.response_wrapper import success_response
 
-router=APIRouter(prefix="/iap", tags=["iap"])
+router = APIRouter(prefix="/iap", tags=["iap"])
+
 
 class ReceiptIn(BaseModel):
-    platform:str  # ios / android
-    receipt:str
+    platform: str  # ios / android
+    receipt: str
+
 
 @router.post("/validate")
-def validate(receipt:ReceiptIn, user=Depends(get_current_user), db:Session=Depends(get_db)):
-    # TODO: call AppStore/Play verification
-    sub=Subscription(user_id=user.id, platform=receipt.platform,
-                     receipt={"raw": receipt.receipt},
-                     current_period_end=datetime.utcnow()+timedelta(days=365))
-    db.add(sub); db.commit()
-    return success_response({"status":"ok","premium_until": sub.current_period_end})
+def validate(
+    receipt: ReceiptIn,
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    result = validate_receipt(user.id, receipt.receipt, receipt.platform)
+    if result.get("status") != "valid":
+        raise HTTPException(status_code=400, detail="Invalid receipt")
+
+    sub = Subscription(
+        user_id=user.id,
+        platform=result["platform"],
+        receipt={"raw": receipt.receipt},
+        current_period_end=datetime.utcnow() + timedelta(days=365),
+    )
+    db.add(sub)
+    db.commit()
+    return success_response(
+        {
+            "status": "ok",
+            "premium_until": sub.current_period_end,
+        }
+    )

--- a/app/api/iap/services.py
+++ b/app/api/iap/services.py
@@ -1,6 +1,22 @@
+"""Very naive receipt validation helpers."""
 
-# TODO: Integrate AppStore / Play validation later
+from typing import Dict
 
-def validate_receipt(user_id: str, receipt: str, platform: str):
-    # Placeholder logic
+
+def validate_receipt(
+    user_id: str,
+    receipt: str,
+    platform: str,
+) -> Dict[str, str]:
+    """Validate receipt contents.
+
+    This stub just checks that the platform is supported and the receipt is
+    not empty. Real integration with App Store or Google Play should be
+    implemented separately.
+    """
+
+    if platform not in {"ios", "android"}:
+        return {"status": "invalid", "reason": "unsupported platform"}
+    if not receipt:
+        return {"status": "invalid", "reason": "empty receipt"}
     return {"status": "valid", "platform": platform}

--- a/app/api/onboarding/routes.py
+++ b/app/api/onboarding/routes.py
@@ -1,10 +1,18 @@
-
-from fastapi import APIRouter
 import json
 from pathlib import Path
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
+from app.core.session import get_db
+from app.engine.calendar_engine_behavioral import build_calendar
+from app.services.budget_planner import generate_budget_from_answers
+from app.services.calendar_service_real import save_calendar_for_user
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/onboarding", tags=["onboarding"])
+
 
 @router.get("/questions", response_model=dict)
 async def get_questions():
@@ -16,23 +24,13 @@ async def get_questions():
     return success_response(data)
 
 
-
-from fastapi import APIRouter, Depends
-from app.core.db import get_db
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
-from app.core.db import get_db
-from app.services.budget_planner import generate_budget_from_answers
-from app.engine.calendar_engine_behavioral import build_calendar
-from app.services.calendar_service_real import save_calendar_for_user
-
-router = APIRouter(prefix="/onboarding", tags=["onboarding"])
-
-FAKE_USER_ID = 1  # TODO: заменить на токен после auth
-
 @router.post("/submit")
-async def submit_onboarding(answers: dict, db: Session = Depends(get_db)):
+async def submit_onboarding(
+    answers: dict,
+    db: Session = Depends(get_db),  # noqa: B008
+    current_user=Depends(get_current_user),  # noqa: B008
+):
     budget_plan = generate_budget_from_answers(answers)
     calendar_data = build_calendar({**answers, **budget_plan})
-    save_calendar_for_user(db, FAKE_USER_ID, calendar_data)
+    save_calendar_for_user(db, current_user.id, calendar_data)
     return {"status": "success", "calendar_days": len(calendar_data)}

--- a/app/api/plan.py
+++ b/app/api/plan.py
@@ -1,15 +1,32 @@
-from app.utils.response_wrapper import success_response
-from fastapi import APIRouter, Depends
 from datetime import date
+
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
 from app.core.session import get_db
 from app.db.models import DailyPlan
-from app.api.dependencies import get_current_user
+from app.utils.response_wrapper import success_response
 
-router=APIRouter(prefix="/plan", tags=["plan"])
+router = APIRouter(prefix="/plan", tags=["plan"])
+
 
 @router.get("/{year}/{month}")
-def plan_month(year:int, month:int, user=Depends(get_current_user), db:Session=Depends(get_db)):
-    rows=db.query(DailyPlan).filter(DailyPlan.user_id==user.id,
-        DailyPlan.date.between(date(year,month,1), date(year,month,28))).all()
-    return success_response({row.date.day:row.plan_json for row in rows})
+def plan_month(
+    year: int,
+    month: int,
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    rows = (
+        db.query(DailyPlan)
+        .filter(
+            DailyPlan.user_id == user.id,
+            DailyPlan.date.between(
+                date(year, month, 1),
+                date(year, month, 28),
+            ),
+        )
+        .all()
+    )
+    return success_response({row.date.day: row.plan_json for row in rows})

--- a/app/core/session.py
+++ b/app/core/session.py
@@ -1,13 +1,15 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from app.core.config import get_settings
 
-settings=get_settings()
-engine=create_engine(settings.DATABASE_URL, echo=False, pool_pre_ping=True)
-SessionLocal=sessionmaker(bind=engine, autocommit=False, autoflush=False)
+settings = get_settings()
+engine = create_engine(settings.DATABASE_URL, echo=False, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
 
 def get_db():
-    db=SessionLocal()
+    db = SessionLocal()
     try:
         yield db
     finally:

--- a/app/core/upstash.py
+++ b/app/core/upstash.py
@@ -1,17 +1,24 @@
+import os
 
 import httpx
 
-UPSTASH_URL = "https://global.api.upstash.com"
-UPSTASH_AUTH_HEADER = {
-    "Authorization": "Bearer AUgCAAIjcDFmNDAzNWFlMGM0NWU0NDQxYjU4OWNhZjg0OTNhYWEzNnAxMA"
-}
+UPSTASH_URL = os.getenv("UPSTASH_URL", "https://global.api.upstash.com")
+UPSTASH_AUTH_TOKEN = os.getenv("UPSTASH_AUTH_TOKEN")
+
+
+def _auth_header() -> dict:
+    if not UPSTASH_AUTH_TOKEN:
+        raise RuntimeError("UPSTASH_AUTH_TOKEN not configured")
+    return {"Authorization": f"Bearer {UPSTASH_AUTH_TOKEN}"}
+
 
 def blacklist_token(jti: str, ttl: int):
     url = f"{UPSTASH_URL}/set/revoked:jwt:{jti}?EX={ttl}"
-    response = httpx.post(url, headers=UPSTASH_AUTH_HEADER)
+    response = httpx.post(url, headers=_auth_header())
     response.raise_for_status()
+
 
 def is_token_blacklisted(jti: str) -> bool:
     url = f"{UPSTASH_URL}/get/revoked:jwt:{jti}"
-    response = httpx.get(url, headers=UPSTASH_AUTH_HEADER)
+    response = httpx.get(url, headers=_auth_header())
     return response.json().get("result") is not None


### PR DESCRIPTION
## Summary
- clean up onboarding routes and use real auth
- add simple receipt validation and use it in IAP API
- configure Upstash client via environment variables
- minor formatting and newline fixes

## Testing
- `pre-commit run --files app/api/iap.py app/api/iap/services.py app/api/onboarding/routes.py app/api/plan.py app/core/session.py app/core/upstash.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails during PyYAML build)*

------
https://chatgpt.com/codex/tasks/task_e_683f620b1958832283b733598b19202b