### PR TITLE
Resolve merge conflicts

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,9 @@
 from functools import lru_cache
+
 try:
     from pydantic_settings import BaseSettings
-except ModuleNotFoundError:  # fallback for environments without pydantic-settings
+except ModuleNotFoundError:
+    # Fallback for environments without pydantic-settings
     from pydantic import BaseSettings
 
 
@@ -32,9 +34,9 @@ class Settings(BaseSettings):
     sentry_dsn: str = ""
 
     class Config:
-        # 🔻 Удалено, потому что Render использует переменные окружения из UI
-        # env_file = "./secrets/.env.production"
-        pass
+        # Render uses environment variables from the UI. The ``env_file``
+        # option remains for local development.
+        env_file = ".env"
 
 
 @lru_cache

--- a/app/engine/behavioral_summary_generator.py
+++ b/app/engine/behavioral_summary_generator.py
@@ -1,9 +1,9 @@
 class BehavioralSummaryGenerator:
     """Compose human readable financial behavior summaries."""
 
-    def __init__(self) -> None:
-        """Initialize the generator with no state for now."""
-        pass
+    # The generator currently has no state, so we rely solely on the input
+    # data when constructing summaries. By omitting ``__init__`` we keep the
+    # class lightweight and avoid unused placeholder code.
 
     def generate(self, profile, analytics_data):
         region = profile.get("region", "unknown")

--- a/app/engine/style_personalization_engine.py
+++ b/app/engine/style_personalization_engine.py
@@ -1,9 +1,8 @@
 class StylePersonalizationEngine:
     """Generate UI and tone tweaks based on user behavior profile."""
 
-    def __init__(self) -> None:
-        """Currently stateless but left for future extensibility."""
-        pass
+    # No initialization logic is required yet. The class remains simple and can
+    # evolve in the future without carrying unused boilerplate.
 
     def adapt(self, profile):
         style = profile.get("behavior", "neutral")

--- a/app/services/core/api/analytics_engine.py
+++ b/app/services/core/api/analytics_engine.py
@@ -12,9 +12,8 @@ from app.services.core.analytics.monthly_aggregator import (
 class AnalyticsEngine:
     """High level API aggregating analytics helpers."""
 
-    def __init__(self) -> None:
-        """Initialize the engine with no state."""
-        pass
+    # The engine simply proxies helper functions. An explicit ``__init__`` is
+    # not needed, which keeps the class lightweight.
 
     def get_monthly_summary(self, calendar: list, month: str) -> dict:
         return aggregate_monthly_data(calendar, month)

--- a/mobile_app/lib/screens/onboarding_expenses_screen.dart
+++ b/mobile_app/lib/screens/onboarding_expenses_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../services/onboarding_state.dart';
 
 class FixedExpense {
   String category;
@@ -31,8 +32,8 @@ class _OnboardingExpensesScreenState extends State<OnboardingExpensesScreen> {
           .map((e) => {"category": e.category, "amount": double.parse(e.amount)})
           .toList();
 
-      // TODO: Подключи к своему API
-      // await ApiService.submitExpenses(apiExpenses);
+      // Preserve expenses for the final onboarding request
+      OnboardingState.instance.expenses = apiExpenses;
 
       Navigator.pushNamed(context, '/onboarding_goal');
     }
@@ -123,7 +124,7 @@ class _OnboardingExpensesScreenState extends State<OnboardingExpensesScreen> {
                                     }
                                     final n = double.tryParse(val);
                                     if (n == null || n <= 0) {
-                                      return ">";
+                                      return "Enter a positive number";
                                     }
                                     return null;
                                   },

--- a/mobile_app/lib/screens/onboarding_finish_screen.dart
+++ b/mobile_app/lib/screens/onboarding_finish_screen.dart
@@ -1,6 +1,7 @@
 
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import '../services/onboarding_state.dart';
 
 class OnboardingFinishScreen extends StatefulWidget {
   const OnboardingFinishScreen({Key? key}) : super(key: key);
@@ -22,14 +23,17 @@ class _OnboardingFinishScreenState extends State<OnboardingFinishScreen> {
 
   Future<void> _submitOnboardingData() async {
     try {
-      // TODO: заменить на реальные значения из состояния/хранилища
+      // Gather answers from the temporary onboarding state
+      final state = OnboardingState.instance;
       final onboardingData = {
-        "region": "EU",
-        "income": 1000,
-        "expenses": 500,
-        "goals": ["save_more", "budgeting"],
-        "habits": ["impulse_buying", "no_budgeting"],
-        "motivation": "Хочу научиться контролировать расходы"
+        "region": state.region,
+        "income": state.income,
+        "expenses": state.expenses,
+        "goals": state.goals,
+        "habits": state.habits,
+        "motivation": state.motivation,
+        if (state.habitsComment != null && state.habitsComment!.isNotEmpty)
+          "habits_comment": state.habitsComment,
       };
 
       await _api.submitOnboarding(onboardingData);

--- a/mobile_app/lib/screens/onboarding_goal_screen.dart
+++ b/mobile_app/lib/screens/onboarding_goal_screen.dart
@@ -1,5 +1,6 @@
 
 import 'package:flutter/material.dart';
+import '../services/onboarding_state.dart';
 
 class OnboardingGoalScreen extends StatefulWidget {
   const OnboardingGoalScreen({Key? key}) : super(key: key);
@@ -30,8 +31,8 @@ class _OnboardingGoalScreenState extends State<OnboardingGoalScreen> {
 
   void _submitGoals() {
     if (selectedGoals.isEmpty) return;
-
-    // TODO: сохранить goals в глобальное состояние или передать напрямую
+    // Save selected goals for the final onboarding request
+    OnboardingState.instance.goals = selectedGoals.toList();
     Navigator.pushNamed(context, '/onboarding_habits');
   }
 

--- a/mobile_app/lib/screens/onboarding_habits_screen.dart
+++ b/mobile_app/lib/screens/onboarding_habits_screen.dart
@@ -1,5 +1,6 @@
 
 import 'package:flutter/material.dart';
+import '../services/onboarding_state.dart';
 
 class OnboardingHabitsScreen extends StatefulWidget {
   const OnboardingHabitsScreen({Key? key}) : super(key: key);
@@ -31,8 +32,9 @@ class _OnboardingHabitsScreenState extends State<OnboardingHabitsScreen> {
 
   void _submitHabits() {
     if (selectedHabits.isEmpty) return;
-
-    // TODO: сохранить habits и комментарий в глобальное состояние или передать напрямую
+    // Save habits and optional comment
+    OnboardingState.instance.habits = selectedHabits.toList();
+    OnboardingState.instance.habitsComment = commentController.text.trim();
     Navigator.pushNamed(context, '/onboarding_motivation');
   }
 

--- a/mobile_app/lib/screens/onboarding_income_screen.dart
+++ b/mobile_app/lib/screens/onboarding_income_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../services/onboarding_state.dart';
 
 class OnboardingIncomeScreen extends StatefulWidget {
   const OnboardingIncomeScreen({Key? key}) : super(key: key);
@@ -15,8 +16,8 @@ class _OnboardingIncomeScreenState extends State<OnboardingIncomeScreen> {
     if (_formKey.currentState?.validate() ?? false) {
       double income = double.parse(_incomeController.text.replaceAll(',', ''));
 
-      // TODO: Подключи к своему API (пример):
-      // await ApiService.submitIncome(income);
+      // Store income until all onboarding data is collected
+      OnboardingState.instance.income = income;
 
       Navigator.pushNamed(context, '/onboarding_expenses');
     }

--- a/mobile_app/lib/screens/onboarding_motivation_screen.dart
+++ b/mobile_app/lib/screens/onboarding_motivation_screen.dart
@@ -1,5 +1,6 @@
 
 import 'package:flutter/material.dart';
+import '../services/onboarding_state.dart';
 
 class OnboardingMotivationScreen extends StatefulWidget {
   const OnboardingMotivationScreen({Key? key}) : super(key: key);
@@ -14,8 +15,8 @@ class _OnboardingMotivationScreenState extends State<OnboardingMotivationScreen>
   void _submitMotivation() {
     final text = _controller.text.trim();
     if (text.isEmpty) return;
-
-    // TODO: сохранить мотивацию
+    // Persist motivation text
+    OnboardingState.instance.motivation = text;
     Navigator.pushNamed(context, '/onboarding_finish');
   }
 

--- a/mobile_app/lib/screens/onboarding_region_screen.dart
+++ b/mobile_app/lib/screens/onboarding_region_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../services/onboarding_state.dart';
 
 class OnboardingRegionScreen extends StatefulWidget {
   const OnboardingRegionScreen({Key? key}) : super(key: key);
@@ -19,8 +20,8 @@ class _OnboardingRegionScreenState extends State<OnboardingRegionScreen> {
   void _submitRegion() async {
     if (selectedRegion == null) return;
 
-    // TODO: Подключи к своему API, если нужно сохранить регион сразу:
-    // await ApiService.submitRegion(selectedRegion);
+    // Persist region choice until the final onboarding step
+    OnboardingState.instance.region = selectedRegion;
 
     Navigator.pushNamed(context, '/onboarding_income');
   }

--- a/mobile_app/lib/services/onboarding_state.dart
+++ b/mobile_app/lib/services/onboarding_state.dart
@@ -1,0 +1,12 @@
+class OnboardingState {
+  OnboardingState._();
+  static final instance = OnboardingState._();
+
+  String? region;
+  double? income;
+  List<Map<String, dynamic>> expenses = [];
+  List<String> goals = [];
+  List<String> habits = [];
+  String? habitsComment;
+  String? motivation;
+}


### PR DESCRIPTION
## Summary
- finalize merge with `j47bwd-codex/проверить-работоспособность-бэкенда`
- remove unused `__init__` methods in the personalization engines
- improve fallback logic in `Settings`
- persist onboarding answers on the Flutter side

## Testing
- `pre-commit run --files app/core/config.py app/engine/behavioral_summary_generator.py app/engine/style_personalization_engine.py app/services/core/api/analytics_engine.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f7b4d761c832288fe60bef6305c19