### PR TITLE
Refactor JWT secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mita
 JWT_SECRET=dev_secret_change
+SECRET_KEY=dev_secret_change
 REDIS_URL=redis://localhost:6379

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 # Mita Finance backend
-FROM python:3.10-slim
-
-WORKDIR /code
+FROM python:3.10-slim AS builder
+WORKDIR /install
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
 
-COPY . .
-
+FROM python:3.10-slim
+WORKDIR /code
 ENV PYTHONPATH=/code
+
+COPY --from=builder /root/.local /usr/local
+COPY . .
 
 # Wait for Postgres before starting backend
 COPY ./wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /wait-for-it.sh
 
-CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ MITA distributes a user’s **monthly income** into **daily budgets per category
 ```
 GOOGLE_CREDENTIALS_PATH=/path/to/ocr.json
 FIREBASE_CONFIGURED=true
-JWT_SECRET_KEY=supersecret
+SECRET_KEY=supersecret
 DATABASE_URL=postgresql://user:pass@localhost:5432/mita
 ```
 
@@ -158,6 +158,8 @@ DATABASE_URL=postgresql://user:pass@localhost:5432/mita
 ## 💻 9. Dev Setup
 
 ### Docker
+The provided Dockerfile now uses a multi-stage build to keep the final image
+small. Build and start the stack with:
 ```bash
 docker-compose up --build
 ```

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,9 +2,13 @@ from functools import lru_cache
 
 try:
     from pydantic_settings import BaseSettings
-except ModuleNotFoundError:
-    # Fallback for environments without pydantic-settings
+except ModuleNotFoundError:  # pragma: no cover - fallback for older pydantic
     from pydantic import BaseSettings
+
+try:
+    from pydantic import ConfigDict
+except ImportError:  # pragma: no cover - pydantic v1 compatibility
+    ConfigDict = None
 
 
 class Settings(BaseSettings):
@@ -33,10 +37,11 @@ class Settings(BaseSettings):
     # Sentry (опционально)
     sentry_dsn: str = ""
 
-    class Config:
-        # Render uses environment variables from the UI. The ``env_file``
-        # option remains for local development.
-        env_file = ".env"
+    if ConfigDict:
+        model_config = ConfigDict(env_file=".env")
+    else:  # pragma: no cover - pydantic v1 fallback
+        class Config:
+            env_file = ".env"
 
 
 @lru_cache

--- a/app/core/jwt_utils.py
+++ b/app/core/jwt_utils.py
@@ -1,11 +1,13 @@
-import os, datetime, uuid
+import os
+import datetime
+import uuid
 import jwt
 from passlib.context import CryptContext
 
-SECRET_KEY=os.getenv "oPh-TW4BNM9vQc2S8DkP0XYhIMeJBS5vMBRT6s9aQ1_rBjhsSTP3adTUxKMZ-cvq6UabCJSEpUaaBMzqAHXbzA"
-ALGORITHM="HS256"
-ACCESS_EXPIRES_MIN=30
-REFRESH_EXPIRES_DAYS=7
+from app.core.config import SECRET_KEY, ALGORITHM, settings
+
+ACCESS_EXPIRES_MIN = settings.ACCESS_TOKEN_EXPIRE_MINUTES
+REFRESH_EXPIRES_DAYS = 7
 
 pwd_context=CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/app/db/models/base.py
+++ b/app/db/models/base.py
@@ -1,4 +1,4 @@
 
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()

--- a/app/services/auth_jwt_service.py
+++ b/app/services/auth_jwt_service.py
@@ -2,9 +2,9 @@
 from datetime import datetime, timedelta
 from jose import JWTError, jwt
 
-SECRET_KEY = "REPLACE_ME"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+from app.core.config import SECRET_KEY, ALGORITHM, settings
+
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 
 # Можно заменить на хранилище в Redis/DB


### PR DESCRIPTION
## Summary
- centralize JWT secret config in `settings`
- document SECRET_KEY usage
- show example SECRET_KEY in `.env.example`
- modernize settings class to use `ConfigDict`
- update SQLAlchemy base import
- shrink Docker image with multi-stage build

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841fac9149c832295daf3db5d3a9278