### PR TITLE
Improve OCR service

### DIFF
--- a/app/ocr/ocr_receipt_service.py
+++ b/app/ocr/ocr_receipt_service.py
@@ -1,47 +1,55 @@
-
-"""
-OCRReceiptService: Service for handling receipt image processing and text extraction.
-"""
+"""OCR receipt processing using Tesseract OCR."""
 
 import os
-import random
+from typing import Dict
+
+import pytesseract
+from PIL import Image
+
+from app.ocr.ocr_parser import parse_receipt_text
+
 
 class OCRReceiptService:
-    """
-    A mock OCR service for extracting data from receipt images.
-    (In production, replace mock behavior with real OCR, e.g., Tesseract or Google Vision API.)
-    """
+    """Simple OCR service backed by Tesseract."""
 
     def __init__(self, temp_dir: str = "/tmp"):
         self.temp_dir = temp_dir
 
-    def process_image(self, image_path: str) -> dict:
-        """
-        Process the uploaded receipt image and extract relevant transaction data.
+    def process_image(self, image_path: str) -> Dict[str, str | float]:
+        """Extract structured data from a receipt image.
 
         Args:
-            image_path (str): Path to the uploaded receipt image.
+            image_path: Path to the uploaded receipt image.
 
         Returns:
-            dict: Extracted information with keys 'store', 'amount', 'date', etc.
+            Dict with keys ``store``, ``amount``, ``category_hint`` and
+            ``date``.
         """
         if not os.path.exists(image_path):
             raise FileNotFoundError("Image file not found.")
 
-        # --- MOCK OCR BEHAVIOR ---
-        stores = ['Walmart', 'Costco', 'Starbucks', 'Amazon', 'McDonalds']
-        categories = ['groceries', 'transport', 'entertainment', 'restaurants']
-        result = {
-            "store": random.choice(stores),
-            "amount": round(random.uniform(5.0, 100.0), 2),
-            "category_hint": random.choice(categories),
-            "date": "2025-04-26"
-        }
-
-        # After processing, delete the image
         try:
-            os.remove(image_path)
-        except Exception as e:
-            print(f"Warning: Could not delete temporary image file: {str(e)}")
+            image = Image.open(image_path)
+            raw_text = pytesseract.image_to_string(image)
+        finally:
+            try:
+                os.remove(image_path)
+            except Exception as e:  # pragma: no cover - best effort cleanup
+                print(f"Warning: Could not delete temporary image file: {e}")
 
-        return result
+        parsed = parse_receipt_text(raw_text)
+
+        # Use the first non-empty line as a store hint
+        store = "unknown"
+        for line in raw_text.splitlines():
+            stripped = line.strip()
+            if stripped:
+                store = stripped[:64]
+                break
+
+        return {
+            "store": store,
+            "amount": parsed["amount"],
+            "category_hint": parsed["category"],
+            "date": parsed["date"],
+        }


### PR DESCRIPTION
## Summary
- replace dummy OCR implementation with a simple Tesseract-based service

## Testing
- `pre-commit run --files app/ocr/ocr_receipt_service.py`
- `pytest app/tests/test_agent_locally.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68421a0a84148322a644cd62e5b55fe1