### PR TITLE
Improve API module formatting

### DIFF
--- a/agent_finance_advisor.py
+++ b/agent_finance_advisor.py
@@ -14,7 +14,10 @@ installment_tool = {
     "type": "function",
     "function": {
         "name": "can_user_afford_installment",
-        "description": "Анализирует, может ли пользователь безопасно взять товар в рассрочку.",
+        "description": (
+            "Анализирует, может ли пользователь безопасно "
+            "взять товар в рассрочку."
+        ),
         "parameters": {
             "type": "object",
             "properties": {

--- a/agent_runner.py
+++ b/agent_runner.py
@@ -1,9 +1,10 @@
 
 import os
-from openai import OpenAI
 from dotenv import load_dotenv
-from app.logic.installment_evaluator import can_user_afford_installment
+from openai import OpenAI
+
 from app.engine.risk_predictor import evaluate_user_risk
+from app.logic.installment_evaluator import can_user_afford_installment
 
 # Загрузка переменных среды
 load_dotenv()
@@ -12,17 +13,23 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
 client = OpenAI(api_key=OPENAI_API_KEY)
 
+
 def run_agent_for_user_message(user_message: str):
     assistant = client.beta.assistants.create(
         name="Finance Advisor Agent",
-        instructions="Ты — финансовый AI-советник. Анализируешь риски и рассрочку. Действуешь строго по фактам.",
+        instructions=(
+            "Ты — финансовый AI-советник. Анализируешь риски и "
+            "рассрочку. Действуешь строго по фактам."
+        ),
         model=OPENAI_MODEL,
         tools=[
             {
                 "type": "function",
                 "function": {
                     "name": "can_user_afford_installment",
-                    "description": "Проверяет, может ли пользователь позволить рассрочку",
+                    "description": (
+                        "Проверяет, может ли пользователь позволить рассрочку"
+                    ),
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -65,11 +72,16 @@ def run_agent_for_user_message(user_message: str):
 
     import time
     while True:
-        run_status = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
+        run_status = client.beta.threads.runs.retrieve(
+            thread_id=thread.id,
+            run_id=run.id,
+        )
         if run_status.status == "completed":
             break
         elif run_status.status == "requires_action":
-            tool_calls = run_status.required_action.submit_tool_outputs.tool_calls
+            tool_calls = (
+                run_status.required_action.submit_tool_outputs.tool_calls
+            )
             tool_outputs = []
 
             for call in tool_calls:
@@ -102,6 +114,7 @@ def run_agent_for_user_message(user_message: str):
             return msg.content[0].text.value
 
     return "Агент не дал ответа."
+
 
 if __name__ == "__main__":
     msg = "Оцени мой риск, если я user_001"

--- a/app/api/behavior/routes.py
+++ b/app/api/behavior/routes.py
@@ -1,12 +1,24 @@
 
 from fastapi import APIRouter
+
 from app.api.behavior.schemas import BehaviorPayload
 from app.services.behavior_service import generate_behavior
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/behavior", tags=["behavior"])
 
+
 @router.post("/calendar", response_model=dict)
 async def generate_behavior_calendar(payload: BehaviorPayload):
-    result = generate_behavior(payload.user_id, payload.year, payload.month, payload.profile, payload.mood_log, payload.challenge_log, payload.calendar_log)
+    """Generate spending behavior calendar for a given user."""
+
+    result = generate_behavior(
+        payload.user_id,
+        payload.year,
+        payload.month,
+        payload.profile,
+        payload.mood_log,
+        payload.challenge_log,
+        payload.calendar_log,
+    )
     return success_response(result)

--- a/app/api/behavior_api.py
+++ b/app/api/behavior_api.py
@@ -1,16 +1,27 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
-from app.services.core.behavior.behavior_service import generate_behavioral_calendar
+
+from app.services.core.behavior.behavior_service import (
+    generate_behavioral_calendar,
+)
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/behavior", tags=["behavior"])
+
 
 class BehaviorRequest(BaseModel):
     start_date: str
     days: int
     category_weights: dict
 
+
 @router.post("/calendar")
 async def get_behavior_calendar(payload: BehaviorRequest):
-    calendar = generate_behavioral_calendar(payload.start_date, payload.days, payload.category_weights)
+    """Return a recommended behavioral spending calendar."""
+
+    calendar = generate_behavioral_calendar(
+        payload.start_date,
+        payload.days,
+        payload.category_weights,
+    )
     return success_response({"calendar": calendar})

--- a/app/api/budget/routes.py
+++ b/app/api/budget/routes.py
@@ -1,19 +1,34 @@
 
 from fastapi import APIRouter, Depends
-from app.core.db import get_db
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
-from app.api.budget.services import fetch_spent_by_category, fetch_remaining_budget
-from app.services.auth_dependency import get_current_user
+
+from app.api.budget.services import (
+    fetch_remaining_budget,
+    fetch_spent_by_category,
+)
 from app.core.db import get_db
-from app.db.models.user import User  # предполагается, что User определён в models
+# предполагается, что User определён в models
+from app.db.models.user import User
+from app.services.auth_dependency import get_current_user
 
 router = APIRouter(prefix="/budget", tags=["budget"])
 
+
 @router.get("/spent")
-async def spent(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+async def spent(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return spending amounts grouped by category."""
+
     return fetch_spent_by_category(db, user.id, 2025, 5)
 
+
 @router.get("/remaining")
-async def remaining(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+async def remaining(
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return the remaining budget for the month."""
+
     return fetch_remaining_budget(db, user.id, 2025, 5)

--- a/app/api/style/routes.py
+++ b/app/api/style/routes.py
@@ -1,11 +1,17 @@
 
 from fastapi import APIRouter
+
 from app.api.style.schemas import StyleRequest, StyleResponse
 from app.api.style.services import get_ui_style
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/style", tags=["style"])
 
+
 @router.post("/", response_model=StyleResponse)
 async def personalize(payload: StyleRequest):
-    return success_response({"style": get_ui_style(payload.user_id, payload.profile)})
+    """Return styling configuration for the UI."""
+
+    return success_response({
+        "style": get_ui_style(payload.user_id, payload.profile),
+    })

--- a/app/api/style_api.py
+++ b/app/api/style_api.py
@@ -5,11 +5,15 @@ from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/style", tags=["style"])
 
+
 class StyleInput(BaseModel):
     user_id: str
     profile: dict
 
+
 @router.post("/personalize")
 async def personalize(payload: StyleInput):
+    """Return personalized styling info for the user."""
+
     result = personalize_ui(payload.user_id, payload.profile)
     return success_response({"style": result})

--- a/app/core/jwt_utils.py
+++ b/app/core/jwt_utils.py
@@ -1,4 +1,3 @@
-import os
 import datetime
 import uuid
 import jwt
@@ -6,30 +5,44 @@ from passlib.context import CryptContext
 
 from app.core.config import SECRET_KEY, ALGORITHM, settings
 
+
 ACCESS_EXPIRES_MIN = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 REFRESH_EXPIRES_DAYS = 7
 
-pwd_context=CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-def create_token(data:dict, expires_delta:datetime.timedelta):
-    to_encode=data.copy()
-    to_encode.update({"exp": datetime.datetime.utcnow()+expires_delta,
-                      "jti": str(uuid.uuid4())})
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def create_token(data: dict, expires_delta: datetime.timedelta) -> str:
+    to_encode = data.copy()
+    to_encode.update({
+        "exp": datetime.datetime.utcnow() + expires_delta,
+        "jti": str(uuid.uuid4()),
+    })
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
-def create_access_token(user_id:str):
-    return create_token({"sub": str(user_id), "type":"access"},
-        datetime.timedelta(minutes=ACCESS_EXPIRES_MIN))
 
-def create_refresh_token(user_id:str):
-    return create_token({"sub": str(user_id), "type":"refresh"},
-        datetime.timedelta(days=REFRESH_EXPIRES_DAYS))
+def create_access_token(user_id: str) -> str:
+    return create_token(
+        {"sub": str(user_id), "type": "access"},
+        datetime.timedelta(minutes=ACCESS_EXPIRES_MIN),
+    )
 
-def verify_password(plain, hashed):
+
+def create_refresh_token(user_id: str) -> str:
+    return create_token(
+        {"sub": str(user_id), "type": "refresh"},
+        datetime.timedelta(days=REFRESH_EXPIRES_DAYS),
+    )
+
+
+def verify_password(plain: str, hashed: str) -> bool:
     return pwd_context.verify(plain, hashed)
 
-def hash_password(plain):
+
+def hash_password(plain: str) -> str:
     return pwd_context.hash(plain)
 
-def decode_token(token:str):
+
+def decode_token(token: str) -> dict:
     return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])

--- a/app/services/core/behavior/behavior_service.py
+++ b/app/services/core/behavior/behavior_service.py
@@ -1,11 +1,22 @@
-from datetime import datetime, timedelta
-from app.services.core.behavior.behavioral_config import BEHAVIORAL_BIAS, COOLDOWN_DAYS
-from app.services.core.behavior.behavioral_budget_allocator import generate_behavioral_distribution as get_behavioral_allocation
+from datetime import datetime
+
+from app.services.core.behavior.behavioral_config import (
+    BEHAVIORAL_BIAS,
+    COOLDOWN_DAYS,
+)
+from app.services.core.behavior.behavioral_budget_allocator import (
+    generate_behavioral_distribution as get_behavioral_allocation,
+)
 
 
-def generate_behavioral_calendar(start_date: str, days: int, category_weights: dict) -> dict:
+def generate_behavioral_calendar(
+    start_date: str,
+    days: int,
+    category_weights: dict,
+) -> dict:
     """
-    Generates a behavioral spending calendar based on start date and category weights.
+    Generates a behavioral spending calendar based on start date and
+    category weights.
 
     Params:
         start_date: str "YYYY-MM-DD"
@@ -16,5 +27,11 @@ def generate_behavioral_calendar(start_date: str, days: int, category_weights: d
         {1: {"coffee": X, ...}, 2: {...}, ..., 30: {...}}
     """
     start_dt = datetime.strptime(start_date, "%Y-%m-%d")
-    plan = get_behavioral_allocation(start_dt, days, category_weights, BEHAVIORAL_BIAS, COOLDOWN_DAYS)
+    plan = get_behavioral_allocation(
+        start_dt,
+        days,
+        category_weights,
+        BEHAVIORAL_BIAS,
+        COOLDOWN_DAYS,
+    )
     return {i + 1: plan[i] for i in range(days)}

--- a/mobile_app/android/app/build.gradle.kts
+++ b/mobile_app/android/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
         release {
             // TODO: Replace with your own release signing config
             signingConfig = signingConfigs.getByName("debug")
-        }○
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- tidy behavior routes and API formatting
- document style personalization endpoints
- clean up budget routes
- format behavior service util and split long lines

## Testing
- `flake8 app/api/behavior/routes.py app/api/behavior_api.py app/api/style_api.py app/api/style/routes.py app/api/budget/routes.py app/services/core/behavior/behavior_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684938964c5483229f7ce84aa6aad590