### PR TITLE
Add JWT token response to Google login

### DIFF
--- a/app/api/auth_api.py
+++ b/app/api/auth_api.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+
 from app.core.db import get_db
+from app.core.jwt_utils import create_access_token, create_refresh_token
 from app.services.google_auth_service import authenticate_google_user
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -12,10 +14,18 @@ class GoogleAuthInput(BaseModel):
 
 
 @router.post("/google")
-def google_login(payload: GoogleAuthInput, db: Session = Depends(get_db)):
+def google_login(
+    payload: GoogleAuthInput,
+    db: Session = Depends(get_db),  # noqa: B008
+):
     user = authenticate_google_user(payload.id_token, db)
+    access = create_access_token(str(user.id))
+    refresh = create_refresh_token(str(user.id))
     return {
-        "user_id": user.id,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "bearer",
+        "user_id": str(user.id),
         "email": user.email,
-        "is_premium": user.is_premium
+        "is_premium": user.is_premium,
     }


### PR DESCRIPTION
## Summary
- issue JWT tokens on Google sign in so mobile app can authenticate

## Testing
- `pre-commit run --files app/api/auth_api.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b46ed7c208322aed9d634e12a0d2e