### PR TITLE
Add token refresh and storage support

### DIFF
--- a/app/api/auth/routes.py
+++ b/app/api/auth/routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 
+import app.core.jwt_utils as jwt_utils
 from app.services.auth_jwt_service import (
     blacklist_token,
     create_access_token,
@@ -14,13 +15,31 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 @router.post("/refresh")
 async def refresh_token(request: Request):
+    """Issue a new access token using either token format."""
     token = request.headers.get("Authorization", "").replace("Bearer ", "")
     payload = verify_token(token, scope="refresh_token")
-    if not payload:
+    if payload:
+        user_data = {k: payload[k] for k in payload}
+        user_data.pop("exp", None)
+        user_data.pop("scope", None)
+        new_access = create_access_token(user_data)
+        return {"access_token": new_access, "token_type": "bearer"}
+
+    # Fallback for legacy tokens without `scope`
+    try:
+        legacy = jwt_utils.decode_token(token)
+        if legacy.get("type") != "refresh":
+            raise ValueError("Incorrect token type")
+        user_id = str(legacy["sub"])
+        access = jwt_utils.create_access_token(user_id)
+        refresh = jwt_utils.create_refresh_token(user_id)
+        return {
+            "access_token": access,
+            "refresh_token": refresh,
+            "token_type": "bearer",
+        }
+    except Exception:
         raise HTTPException(status_code=401, detail="Invalid refresh token")
-    user_data = {k: payload[k] for k in payload if k != "exp" and k != "scope"}
-    new_access = create_access_token(user_data)
-    return {"access_token": new_access, "token_type": "bearer"}
 
 
 @router.post("/logout")

--- a/app/api/auth_api.py
+++ b/app/api/auth_api.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+
 from app.core.db import get_db
+from app.core.jwt_utils import create_access_token, create_refresh_token
 from app.services.google_auth_service import authenticate_google_user
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -12,10 +14,18 @@ class GoogleAuthInput(BaseModel):
 
 
 @router.post("/google")
-def google_login(payload: GoogleAuthInput, db: Session = Depends(get_db)):
+def google_login(
+    payload: GoogleAuthInput,
+    db: Session = Depends(get_db),  # noqa: B008
+):
     user = authenticate_google_user(payload.id_token, db)
+    access = create_access_token(str(user.id))
+    refresh = create_refresh_token(str(user.id))
     return {
-        "user_id": user.id,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "bearer",
+        "user_id": str(user.id),
         "email": user.email,
-        "is_premium": user.is_premium
+        "is_premium": user.is_premium,
     }

--- a/mobile_app/lib/screens/login_screen.dart
+++ b/mobile_app/lib/screens/login_screen.dart
@@ -43,7 +43,8 @@ class _LoginScreenState extends State<LoginScreen> {
 
       final response = await _api.loginWithGoogle(idToken);
       final accessToken = response.data['access_token'];
-      await _api.saveToken(accessToken);
+      final refreshToken = response.data['refresh_token'];
+      await _api.saveTokens(accessToken, refreshToken);
 
       if (!mounted) return;
       Navigator.pushReplacementNamed(context, '/main');


### PR DESCRIPTION
## Summary
- support both token formats on refresh route
- store access and refresh tokens in mobile app
- automatically attach tokens and refresh on 401

## Testing
- `pre-commit run --files app/api/auth/routes.py mobile_app/lib/services/api_service.dart mobile_app/lib/screens/login_screen.dart`
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_684b46ed7c208322aed9d634e12a0d2e