### PR TITLE
Improve API integration

### DIFF
--- a/app/api/auth/routes.py
+++ b/app/api/auth/routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 
+import app.core.jwt_utils as jwt_utils
 from app.services.auth_jwt_service import (
     blacklist_token,
     create_access_token,
@@ -14,13 +15,31 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 @router.post("/refresh")
 async def refresh_token(request: Request):
+    """Issue a new access token using either token format."""
     token = request.headers.get("Authorization", "").replace("Bearer ", "")
     payload = verify_token(token, scope="refresh_token")
-    if not payload:
+    if payload:
+        user_data = {k: payload[k] for k in payload}
+        user_data.pop("exp", None)
+        user_data.pop("scope", None)
+        new_access = create_access_token(user_data)
+        return {"access_token": new_access, "token_type": "bearer"}
+
+    # Fallback for legacy tokens without `scope`
+    try:
+        legacy = jwt_utils.decode_token(token)
+        if legacy.get("type") != "refresh":
+            raise ValueError("Incorrect token type")
+        user_id = str(legacy["sub"])
+        access = jwt_utils.create_access_token(user_id)
+        refresh = jwt_utils.create_refresh_token(user_id)
+        return {
+            "access_token": access,
+            "refresh_token": refresh,
+            "token_type": "bearer",
+        }
+    except Exception:
         raise HTTPException(status_code=401, detail="Invalid refresh token")
-    user_data = {k: payload[k] for k in payload if k != "exp" and k != "scope"}
-    new_access = create_access_token(user_data)
-    return {"access_token": new_access, "token_type": "bearer"}
 
 
 @router.post("/logout")

--- a/app/api/auth_api.py
+++ b/app/api/auth_api.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+
 from app.core.db import get_db
+from app.core.jwt_utils import create_access_token, create_refresh_token
 from app.services.google_auth_service import authenticate_google_user
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -12,10 +14,18 @@ class GoogleAuthInput(BaseModel):
 
 
 @router.post("/google")
-def google_login(payload: GoogleAuthInput, db: Session = Depends(get_db)):
+def google_login(
+    payload: GoogleAuthInput,
+    db: Session = Depends(get_db),  # noqa: B008
+):
     user = authenticate_google_user(payload.id_token, db)
+    access = create_access_token(str(user.id))
+    refresh = create_refresh_token(str(user.id))
     return {
-        "user_id": user.id,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "bearer",
+        "user_id": str(user.id),
         "email": user.email,
-        "is_premium": user.is_premium
+        "is_premium": user.is_premium,
     }

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -39,7 +39,7 @@ class MITAApp extends StatelessWidget {
         scaffoldBackgroundColor: const Color(0xFFFFF9F0),
         fontFamily: 'Manrope',
       ),
-      initialRoute: '/home',
+      initialRoute: '/',
       routes: {
         '/': (context) => const WelcomeScreen(),
         '/login': (context) => const LoginScreen(), // 👈 добавлен логин

--- a/mobile_app/lib/screens/login_screen.dart
+++ b/mobile_app/lib/screens/login_screen.dart
@@ -43,7 +43,10 @@ class _LoginScreenState extends State<LoginScreen> {
 
       final response = await _api.loginWithGoogle(idToken);
       final accessToken = response.data['access_token'];
-      await _api.saveToken(accessToken);
+      final refreshToken = response.data['refresh_token'];
+      final userId = response.data['user_id'];
+      await _api.saveTokens(accessToken, refreshToken);
+      await _api.saveUserId(userId);
 
       if (!mounted) return;
       Navigator.pushReplacementNamed(context, '/main');

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -146,7 +146,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: _isSaving
+                  child: _isSaving
                           ? const CircularProgressIndicator()
                           : const Text(
                               'Save Changes',
@@ -156,11 +156,39 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
+                  ),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: () async {
+                      await _apiService.logout();
+                      if (!mounted) return;
+                      Navigator.pushNamedAndRemoveUntil(
+                        context,
+                        '/login',
+                        (route) => false,
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red.shade400,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                     ),
-                  ],
-                ),
+                    child: const Text(
+                      'Log Out',
+                      style: TextStyle(
+                        fontFamily: 'Sora',
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
+          ),
     );
   }
 }

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -1,16 +1,48 @@
 
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
-import 'dart:convert';
 
 class ApiService {
-  final Dio _dio = Dio(BaseOptions(
-    baseUrl: 'https://mita-docker-ready-project-manus.onrender.com',
-    connectTimeout: const Duration(seconds: 10),
-    receiveTimeout: const Duration(seconds: 10),
-    contentType: 'application/json',
-  ));
+  ApiService() {
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final token = await getToken();
+          if (token != null) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+          handler.next(options);
+        },
+        onError: (DioError e, handler) async {
+          if (e.response?.statusCode == 401) {
+            final refreshed = await _refreshTokens();
+            if (refreshed) {
+              final req = e.requestOptions;
+              final token = await getToken();
+              if (token != null) {
+                req.headers['Authorization'] = 'Bearer $token';
+              }
+              final clone = await _dio.fetch(req);
+              return handler.resolve(clone);
+            }
+          }
+          handler.next(e);
+        },
+      ),
+    );
+  }
+
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: 'https://mita-docker-ready-project-manus.onrender.com',
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      contentType: 'application/json',
+    ),
+  );
 
   final _storage = const FlutterSecureStorage();
 
@@ -18,8 +50,65 @@ class ApiService {
     return await _storage.read(key: 'access_token');
   }
 
-  Future<void> saveToken(String token) async {
-    await _storage.write(key: 'access_token', value: token);
+  Future<String?> getRefreshToken() async {
+    return await _storage.read(key: 'refresh_token');
+  }
+
+  Future<void> saveTokens(String access, String refresh) async {
+    await _storage.write(key: 'access_token', value: access);
+    await _storage.write(key: 'refresh_token', value: refresh);
+  }
+
+  Future<void> saveUserId(String id) async {
+    await _storage.write(key: 'user_id', value: id);
+  }
+
+  Future<String?> getUserId() async {
+    return await _storage.read(key: 'user_id');
+  }
+
+  Future<void> clearTokens() async {
+    await _storage.delete(key: 'access_token');
+    await _storage.delete(key: 'refresh_token');
+  }
+
+  Future<void> logout() async {
+    final refresh = await getRefreshToken();
+    if (refresh != null) {
+      try {
+        await _dio.post(
+          '/api/auth/logout',
+          options: Options(headers: {'Authorization': 'Bearer $refresh'}),
+        );
+      } catch (_) {
+        // ignore errors during logout
+      }
+    }
+    await clearTokens();
+  }
+
+  Future<bool> _refreshTokens() async {
+    final refresh = await getRefreshToken();
+    if (refresh == null) return false;
+    try {
+      final response = await _dio.post(
+        '/api/auth/refresh',
+        options: Options(headers: {'Authorization': 'Bearer $refresh'}),
+      );
+      final data = response.data as Map<String, dynamic>;
+      final newAccess = data['access_token'] as String?;
+      final newRefresh = data['refresh_token'] as String?;
+      if (newAccess != null) {
+        await _storage.write(key: 'access_token', value: newAccess);
+      }
+      if (newRefresh != null) {
+        await _storage.write(key: 'refresh_token', value: newRefresh);
+      }
+      return true;
+    } catch (_) {
+      await clearTokens();
+      return false;
+    }
   }
 
   Future<Response> loginWithGoogle(String idToken) async {
@@ -32,10 +121,10 @@ class ApiService {
   Future<void> submitOnboarding(Map<String, dynamic> data) async {
     final token = await getToken();
     final response = await _dio.post(
-      '/api/onboarding/onboarding/submit',
+      '/api/onboarding/submit',
       data: data,
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -46,7 +135,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/dashboard/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -58,7 +147,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/calendar/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -67,11 +156,16 @@ class ApiService {
 
   Future<void> createExpense(Map<String, dynamic> data) async {
     final token = await getToken();
+    final userId = await getUserId();
     await _dio.post(
-      '/api/expenses/create/',
-      data: data,
+      '/api/expense/add',
+      data: {
+        'user_id': userId,
+        'action': 'add_expense',
+        'payload': data,
+      },
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
   }
@@ -82,7 +176,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/goals/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -93,24 +187,24 @@ class ApiService {
     await _dio.post(
       '/api/goals/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
   Future<void> updateGoal(int id, Map<String, dynamic> data) async {
     final token = await getToken();
     await _dio.patch(
-      '/api/goals/\$id/',
+      '/api/goals/$id/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
   Future<void> deleteGoal(int id) async {
     final token = await getToken();
     await _dio.delete(
-      '/api/goals/\$id/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      '/api/goals/$id/',
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -120,7 +214,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/insights/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return Map<String, dynamic>.from(response.data);
@@ -132,7 +226,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/user/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return Map<String, dynamic>.from(response.data);
@@ -144,7 +238,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/installments/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -153,23 +247,25 @@ class ApiService {
 
   Future<List<dynamic>> getExpenses() async {
     final token = await getToken();
-    final response = await _dio.get(
-      '/api/expenses/',
+    final userId = await getUserId();
+    final response = await _dio.post(
+      '/api/expense/history',
+      data: {'user_id': userId},
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
-    return response.data;
+    return response.data['data']['expenses'];
   }
 
 
   Future<void> updateExpense(int id, Map<String, dynamic> data) async {
     final token = await getToken();
     await _dio.patch(
-      '/api/expenses/\$id/',
+      '/api/expenses/$id/',
       data: data,
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
   }
@@ -177,9 +273,9 @@ class ApiService {
   Future<void> deleteExpense(int id) async {
     final token = await getToken();
     await _dio.delete(
-      '/api/expenses/\$id/',
+      '/api/expenses/$id/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
   }
@@ -188,7 +284,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/user/profile/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -198,7 +294,7 @@ class ApiService {
     await _dio.patch(
       '/api/user/profile/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -207,7 +303,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/notifications/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -217,7 +313,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/habits/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -227,24 +323,24 @@ class ApiService {
     await _dio.post(
       '/api/habits/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
   Future<void> updateHabit(int id, Map<String, dynamic> data) async {
     final token = await getToken();
     await _dio.patch(
-      '/api/habits/\$id/',
+      '/api/habits/$id/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
   Future<void> deleteHabit(int id) async {
     final token = await getToken();
     await _dio.delete(
-      '/api/habits/\$id/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      '/api/habits/$id/',
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -253,7 +349,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/daily-budget/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -262,7 +358,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/analytics/monthly/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }


### PR DESCRIPTION
## Summary
- store user id alongside tokens after login
- refresh onboarding submission path
- add token header fixes in API service
- adjust expense routes to match backend
- include logout method and button in profile screen

## Testing
- `pre-commit run --files mobile_app/lib/services/api_service.dart mobile_app/lib/screens/profile_screen.dart`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b46ed7c208322aed9d634e12a0d2e