### PR TITLE
Improve API integration

### DIFF
--- a/app/api/auth/routes.py
+++ b/app/api/auth/routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 
+import app.core.jwt_utils as jwt_utils
 from app.services.auth_jwt_service import (
     blacklist_token,
     create_access_token,
@@ -14,13 +15,31 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 @router.post("/refresh")
 async def refresh_token(request: Request):
+    """Issue a new access token using either token format."""
     token = request.headers.get("Authorization", "").replace("Bearer ", "")
     payload = verify_token(token, scope="refresh_token")
-    if not payload:
+    if payload:
+        user_data = {k: payload[k] for k in payload}
+        user_data.pop("exp", None)
+        user_data.pop("scope", None)
+        new_access = create_access_token(user_data)
+        return {"access_token": new_access, "token_type": "bearer"}
+
+    # Fallback for legacy tokens without `scope`
+    try:
+        legacy = jwt_utils.decode_token(token)
+        if legacy.get("type") != "refresh":
+            raise ValueError("Incorrect token type")
+        user_id = str(legacy["sub"])
+        access = jwt_utils.create_access_token(user_id)
+        refresh = jwt_utils.create_refresh_token(user_id)
+        return {
+            "access_token": access,
+            "refresh_token": refresh,
+            "token_type": "bearer",
+        }
+    except Exception:
         raise HTTPException(status_code=401, detail="Invalid refresh token")
-    user_data = {k: payload[k] for k in payload if k != "exp" and k != "scope"}
-    new_access = create_access_token(user_data)
-    return {"access_token": new_access, "token_type": "bearer"}
 
 
 @router.post("/logout")

--- a/app/api/auth_api.py
+++ b/app/api/auth_api.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+
 from app.core.db import get_db
+from app.core.jwt_utils import create_access_token, create_refresh_token
 from app.services.google_auth_service import authenticate_google_user
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -12,10 +14,18 @@ class GoogleAuthInput(BaseModel):
 
 
 @router.post("/google")
-def google_login(payload: GoogleAuthInput, db: Session = Depends(get_db)):
+def google_login(
+    payload: GoogleAuthInput,
+    db: Session = Depends(get_db),  # noqa: B008
+):
     user = authenticate_google_user(payload.id_token, db)
+    access = create_access_token(str(user.id))
+    refresh = create_refresh_token(str(user.id))
     return {
-        "user_id": user.id,
+        "access_token": access,
+        "refresh_token": refresh,
+        "token_type": "bearer",
+        "user_id": str(user.id),
         "email": user.email,
-        "is_premium": user.is_premium
+        "is_premium": user.is_premium,
     }

--- a/app/api/expense/routes.py
+++ b/app/api/expense/routes.py
@@ -1,15 +1,25 @@
-
 from fastapi import APIRouter
-from app.schemas.expense import ExpenseEntry, ExpenseHistoryRequest, ExpenseOut, ExpenseHistoryOut
-from app.services.expense_service import add_user_expense, get_user_expense_history
+
+from app.schemas.expense import (
+    ExpenseEntry,
+    ExpenseHistoryOut,
+    ExpenseHistoryRequest,
+    ExpenseOut,
+)
+from app.services.expense_service import (  # noqa: E501
+    add_user_expense,
+    get_user_expense_history,
+)
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/expense", tags=["expense"])
+
 
 @router.post("/add", response_model=ExpenseOut)
 async def add_expense(entry: ExpenseEntry):
     result = add_user_expense(entry.dict())
     return success_response(result)
+
 
 @router.post("/history", response_model=ExpenseHistoryOut)
 async def get_history(request: ExpenseHistoryRequest):

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -39,7 +39,7 @@ class MITAApp extends StatelessWidget {
         scaffoldBackgroundColor: const Color(0xFFFFF9F0),
         fontFamily: 'Manrope',
       ),
-      initialRoute: '/home',
+      initialRoute: '/',
       routes: {
         '/': (context) => const WelcomeScreen(),
         '/login': (context) => const LoginScreen(), // 👈 добавлен логин

--- a/mobile_app/lib/screens/login_screen.dart
+++ b/mobile_app/lib/screens/login_screen.dart
@@ -43,7 +43,10 @@ class _LoginScreenState extends State<LoginScreen> {
 
       final response = await _api.loginWithGoogle(idToken);
       final accessToken = response.data['access_token'];
-      await _api.saveToken(accessToken);
+      final refreshToken = response.data['refresh_token'];
+      final userId = response.data['user_id'];
+      await _api.saveTokens(accessToken, refreshToken);
+      await _api.saveUserId(userId);
 
       if (!mounted) return;
       Navigator.pushReplacementNamed(context, '/main');

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -146,7 +146,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                      child: _isSaving
+                  child: _isSaving
                           ? const CircularProgressIndicator()
                           : const Text(
                               'Save Changes',
@@ -156,11 +156,39 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
+                  ),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: () async {
+                      await _apiService.logout();
+                      if (!mounted) return;
+                      Navigator.pushNamedAndRemoveUntil(
+                        context,
+                        '/login',
+                        (route) => false,
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red.shade400,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                     ),
-                  ],
-                ),
+                    child: const Text(
+                      'Log Out',
+                      style: TextStyle(
+                        fontFamily: 'Sora',
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
+          ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- store user id alongside tokens after login
- refresh onboarding submission path
- add token header fixes in API service
- adjust expense routes to match backend
- include logout method and button in profile screen
- clean API service imports and fix expense routes

## Testing
- `pre-commit run --files mobile_app/lib/services/api_service.dart app/api/expense/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b46ed7c208322aed9d634e12a0d2e