### PR TITLE
Implement user id storage and logout

### DIFF
--- a/app/api/expense/routes.py
+++ b/app/api/expense/routes.py
@@ -1,15 +1,25 @@
-
 from fastapi import APIRouter
-from app.schemas.expense import ExpenseEntry, ExpenseHistoryRequest, ExpenseOut, ExpenseHistoryOut
-from app.services.expense_service import add_user_expense, get_user_expense_history
+
+from app.schemas.expense import (
+    ExpenseEntry,
+    ExpenseHistoryOut,
+    ExpenseHistoryRequest,
+    ExpenseOut,
+)
+from app.services.expense_service import (  # noqa: E501
+    add_user_expense,
+    get_user_expense_history,
+)
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/expense", tags=["expense"])
+
 
 @router.post("/add", response_model=ExpenseOut)
 async def add_expense(entry: ExpenseEntry):
     result = add_user_expense(entry.dict())
     return success_response(result)
+
 
 @router.post("/history", response_model=ExpenseHistoryOut)
 async def get_history(request: ExpenseHistoryRequest):

--- a/mobile_app/lib/screens/login_screen.dart
+++ b/mobile_app/lib/screens/login_screen.dart
@@ -44,7 +44,9 @@ class _LoginScreenState extends State<LoginScreen> {
       final response = await _api.loginWithGoogle(idToken);
       final accessToken = response.data['access_token'];
       final refreshToken = response.data['refresh_token'];
+      final userId = response.data['user_id'];
       await _api.saveTokens(accessToken, refreshToken);
+      await _api.saveUserId(userId);
 
       if (!mounted) return;
       Navigator.pushReplacementNamed(context, '/main');

--- a/mobile_app/lib/screens/onboarding_finish_screen.dart
+++ b/mobile_app/lib/screens/onboarding_finish_screen.dart
@@ -38,6 +38,8 @@ class _OnboardingFinishScreenState extends State<OnboardingFinishScreen> {
 
       await _api.submitOnboarding(onboardingData);
 
+      OnboardingState.instance.reset();
+
       if (!mounted) return;
       setState(() {
         _loading = false;

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -135,6 +135,31 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       ),
                     ),
 
+                    const SizedBox(height: 20),
+                    ElevatedButton(
+                      onPressed: () async {
+                        await _apiService.logout();
+                        if (!mounted) return;
+                        Navigator.pushReplacementNamed(context, '/login');
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF193C57),
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text(
+                        'Log Out',
+                        style: TextStyle(
+                          fontFamily: 'Sora',
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+
                     const Spacer(),
                     ElevatedButton(
                       onPressed: _isSaving ? null : saveProfile,

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -1,9 +1,6 @@
 
-import 'dart:convert';
-
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:http/http.dart' as http;
 
 class ApiService {
   ApiService() {
@@ -59,6 +56,14 @@ class ApiService {
     await _storage.write(key: 'refresh_token', value: refresh);
   }
 
+  Future<void> saveUserId(String id) async {
+    await _storage.write(key: 'user_id', value: id);
+  }
+
+  Future<String?> getUserId() async {
+    return await _storage.read(key: 'user_id');
+  }
+
   Future<void> clearTokens() async {
     await _storage.delete(key: 'access_token');
     await _storage.delete(key: 'refresh_token');
@@ -98,10 +103,10 @@ class ApiService {
   Future<void> submitOnboarding(Map<String, dynamic> data) async {
     final token = await getToken();
     final response = await _dio.post(
-      '/api/onboarding/onboarding/submit',
+      '/api/onboarding/submit',
       data: data,
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -112,7 +117,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/dashboard/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -124,7 +129,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/calendar/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -133,11 +138,12 @@ class ApiService {
 
   Future<void> createExpense(Map<String, dynamic> data) async {
     final token = await getToken();
+    final userId = await getUserId();
     await _dio.post(
-      '/api/expenses/create/',
-      data: data,
+      '/api/expense/add',
+      data: {...data, 'user_id': userId},
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
   }
@@ -148,7 +154,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/goals/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -159,7 +165,7 @@ class ApiService {
     await _dio.post(
       '/api/goals/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -168,7 +174,7 @@ class ApiService {
     await _dio.patch(
       '/api/goals/\$id/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -176,7 +182,7 @@ class ApiService {
     final token = await getToken();
     await _dio.delete(
       '/api/goals/\$id/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -186,7 +192,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/insights/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return Map<String, dynamic>.from(response.data);
@@ -198,7 +204,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/user/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return Map<String, dynamic>.from(response.data);
@@ -210,7 +216,7 @@ class ApiService {
     final response = await _dio.get(
       '/api/installments/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -219,10 +225,12 @@ class ApiService {
 
   Future<List<dynamic>> getExpenses() async {
     final token = await getToken();
-    final response = await _dio.get(
-      '/api/expenses/',
+    final userId = await getUserId();
+    final response = await _dio.post(
+      '/api/expense/history',
+      data: {'user_id': userId},
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
     return response.data;
@@ -235,7 +243,7 @@ class ApiService {
       '/api/expenses/\$id/',
       data: data,
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
   }
@@ -245,7 +253,7 @@ class ApiService {
     await _dio.delete(
       '/api/expenses/\$id/',
       options: Options(
-        headers: {'Authorization': 'Bearer \$token'},
+        headers: {'Authorization': 'Bearer $token'},
       ),
     );
   }
@@ -254,7 +262,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/user/profile/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -264,7 +272,7 @@ class ApiService {
     await _dio.patch(
       '/api/user/profile/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -273,7 +281,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/notifications/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -283,7 +291,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/habits/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -293,7 +301,7 @@ class ApiService {
     await _dio.post(
       '/api/habits/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -302,7 +310,7 @@ class ApiService {
     await _dio.patch(
       '/api/habits/\$id/',
       data: data,
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -310,7 +318,7 @@ class ApiService {
     final token = await getToken();
     await _dio.delete(
       '/api/habits/\$id/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
   }
 
@@ -319,7 +327,7 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/daily-budget/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
   }
@@ -328,9 +336,21 @@ class ApiService {
     final token = await getToken();
     final response = await _dio.get(
       '/api/analytics/monthly/',
-      options: Options(headers: {'Authorization': 'Bearer \$token'}),
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
+  }
+
+  Future<void> logout() async {
+    final token = await getToken();
+    if (token != null) {
+      await _dio.post(
+        '/api/auth/logout',
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+    }
+    await clearTokens();
+    await _storage.delete(key: 'user_id');
   }
 
 }

--- a/mobile_app/lib/services/onboarding_state.dart
+++ b/mobile_app/lib/services/onboarding_state.dart
@@ -9,4 +9,14 @@ class OnboardingState {
   List<String> habits = [];
   String? habitsComment;
   String? motivation;
+
+  void reset() {
+    region = null;
+    income = null;
+    expenses = [];
+    goals = [];
+    habits = [];
+    habitsComment = null;
+    motivation = null;
+  }
 }


### PR DESCRIPTION
## Summary
- save user ID alongside JWT tokens
- fix onboarding endpoint and expense routes
- support logout request and add log out button on profile screen
- clean up API imports and format expense router
- clear onboarding data after submission

## Testing
- `pre-commit run --files mobile_app/lib/services/api_service.dart mobile_app/lib/screens/login_screen.dart mobile_app/lib/screens/profile_screen.dart app/api/expense/routes.py mobile_app/lib/services/onboarding_state.dart mobile_app/lib/screens/onboarding_finish_screen.dart`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b577d8d108322b6b30c7c8cd39288