### PR TITLE
Include openai dependency

### DIFF
--- a/alembic/versions/0003_goals.py
+++ b/alembic/versions/0003_goals.py
@@ -1,0 +1,37 @@
+"""add goals table"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "0003_goals"
+down_revision = "0002_mood"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "goals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("target_amount", sa.Numeric(), nullable=False),
+        sa.Column(
+            "saved_amount",
+            sa.Numeric(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table("goals")

--- a/alembic/versions/0004_user_premium_until.py
+++ b/alembic/versions/0004_user_premium_until.py
@@ -1,0 +1,21 @@
+"""add premium_until field to user"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0004_user_premium_until"
+down_revision = "0003_goals"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("premium_until", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("users", "premium_until")

--- a/app/api/assistant_chat_api.py
+++ b/app/api/assistant_chat_api.py
@@ -1,0 +1,34 @@
+import os
+
+from fastapi import APIRouter, Depends
+from openai.types.chat import ChatCompletionMessageParam
+from pydantic import BaseModel
+
+from app.agent.gpt_agent_service import GPTAgentService
+from app.api.dependencies import get_current_user
+from app.utils.response_wrapper import success_response
+
+router = APIRouter(prefix="/assistant", tags=["assistant"])
+
+GPT = GPTAgentService(api_key=os.getenv("OPENAI_API_KEY", ""))
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]
+
+
+@router.post("/chat")
+async def chat(
+    payload: ChatRequest,
+    user=Depends(get_current_user),  # noqa: B008
+):
+    msgs: list[ChatCompletionMessageParam] = [
+        {"role": m.role, "content": m.content} for m in payload.messages
+    ]
+    reply = GPT.ask(msgs)
+    return success_response({"reply": reply})

--- a/app/api/challenge_progress_api.py
+++ b/app/api/challenge_progress_api.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.engine.challenge_engine_auto import auto_run_challenge_streak
+from app.utils.response_wrapper import success_response
+
+router = APIRouter(prefix="/challenge", tags=["challenge"])
+
+
+class ProgressInput(BaseModel):
+    calendar: list
+    user_id: str
+    log_data: dict | None = None
+
+
+@router.post("/progress")
+async def challenge_progress(payload: ProgressInput):
+    """Return streak progress and reward eligibility."""
+    result = auto_run_challenge_streak(
+        payload.calendar,
+        payload.user_id,
+        payload.log_data or {},
+    )
+    total_days = len(payload.calendar) or 1
+    progress_pct = round(result.get("streak_days", 0) / total_days * 100, 1)
+    return success_response({"progress_pct": progress_pct, **result})
+

--- a/app/api/goals/__init__.py
+++ b/app/api/goals/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/app/api/goals/routes.py
+++ b/app/api/goals/routes.py
@@ -1,0 +1,118 @@
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
+from app.core.session import get_db
+from app.db.models import Goal
+from app.utils.response_wrapper import success_response
+
+router = APIRouter(prefix="", tags=["goals"])
+
+
+class GoalIn(BaseModel):
+    title: str
+    target_amount: float
+
+
+class GoalUpdate(BaseModel):
+    title: Optional[str] = None
+    target_amount: Optional[float] = None
+
+
+class GoalOut(BaseModel):
+    id: UUID
+    title: str
+    target_amount: float
+    saved_amount: float
+
+
+@router.post("/", response_model=GoalOut)
+def create_goal(
+    data: GoalIn,
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    goal = Goal(
+        user_id=user.id,
+        title=data.title,
+        target_amount=data.target_amount,
+    )
+    db.add(goal)
+    db.commit()
+    db.refresh(goal)
+    return success_response(
+        {
+            "id": goal.id,
+            "title": goal.title,
+            "target_amount": float(goal.target_amount),
+            "saved_amount": float(goal.saved_amount),
+        }
+    )
+
+
+@router.get("/", response_model=List[GoalOut])
+def list_goals(
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    goals = db.query(Goal).filter(Goal.user_id == user.id).all()
+    return success_response(
+        [
+            {
+                "id": g.id,
+                "title": g.title,
+                "target_amount": float(g.target_amount),
+                "saved_amount": float(g.saved_amount),
+            }
+            for g in goals
+        ]
+    )
+
+
+@router.patch("/{goal_id}")
+def update_goal(
+    goal_id: UUID,
+    data: GoalUpdate,
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    goal = (
+        db.query(Goal)
+        .filter(
+            Goal.id == goal_id,
+            Goal.user_id == user.id,
+        )
+        .first()
+    )
+    if not goal:
+        return success_response({"error": "not found"})
+    if data.title is not None:
+        goal.title = data.title
+    if data.target_amount is not None:
+        goal.target_amount = data.target_amount
+    db.commit()
+    return success_response({"status": "updated"})
+
+
+@router.delete("/{goal_id}")
+def delete_goal(
+    goal_id: UUID,
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    goal = (
+        db.query(Goal)
+        .filter(
+            Goal.id == goal_id,
+            Goal.user_id == user.id,
+        )
+        .first()
+    )
+    if goal:
+        db.delete(goal)
+        db.commit()
+    return success_response({"status": "deleted"})

--- a/app/api/iap/routes.py
+++ b/app/api/iap/routes.py
@@ -1,14 +1,46 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 
 from app.api.iap.schemas import IAPReceipt
 from app.api.iap.services import validate_receipt
+from app.core.session import get_db
+from app.db.models import Subscription, User
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/iap", tags=["iap"])
 
 
 @router.post("/validate", response_model=dict)
-async def validate(payload: IAPReceipt):
+async def validate(
+    payload: IAPReceipt,
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    result = validate_receipt(
+        payload.user_id,
+        payload.receipt,
+        payload.platform,
+    )
+    if result.get("status") != "valid":
+        return success_response(result)
+
+    sub = Subscription(
+        user_id=payload.user_id,
+        platform=result["platform"],
+        receipt={"raw": payload.receipt},
+        current_period_end=result["expires_at"],
+    )
+    db.add(sub)
+
+    user = db.query(User).filter(User.id == payload.user_id).first()
+    if user:
+        user.is_premium = True
+        user.premium_until = result["expires_at"]
+
+    db.commit()
+
     return success_response(
-        validate_receipt(payload.user_id, payload.receipt, payload.platform)
+        {
+            "status": "ok",
+            "premium_until": result["expires_at"],
+        }
     )

--- a/app/api/iap/services.py
+++ b/app/api/iap/services.py
@@ -1,5 +1,6 @@
-"""Very naive receipt validation helpers."""
+"""Very naive receipt validation helpers with simulated expiration."""
 
+from datetime import datetime, timedelta
 from typing import Dict
 
 
@@ -10,13 +11,19 @@ def validate_receipt(
 ) -> Dict[str, str]:
     """Validate receipt contents.
 
-    This stub just checks that the platform is supported and the receipt is
-    not empty. Real integration with App Store or Google Play should be
-    implemented separately.
+    This stub now returns an expiration timestamp. Real integration with
+    App Store or Google Play should be implemented separately.
     """
 
     if platform not in {"ios", "android"}:
         return {"status": "invalid", "reason": "unsupported platform"}
     if not receipt:
         return {"status": "invalid", "reason": "empty receipt"}
-    return {"status": "valid", "platform": platform}
+
+    days = 365 if "year" in receipt else 30
+    expiration = datetime.utcnow() + timedelta(days=days)
+    return {
+        "status": "valid",
+        "platform": platform,
+        "expires_at": expiration,
+    }

--- a/app/api/transactions.py
+++ b/app/api/transactions.py
@@ -10,6 +10,7 @@ from app.api.dependencies import get_current_user
 from app.core.session import get_db
 from app.db.models import Transaction
 from app.schemas.core_outputs import TransactionOut
+from app.services.core.engine.expense_tracker import apply_transaction_to_plan
 from app.utils.response_wrapper import success_response
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
@@ -38,6 +39,7 @@ def add_txn(
     db.add(t)
     db.commit()
     db.refresh(t)
+    apply_transaction_to_plan(db, t)
     return success_response({"id": str(t.id)})
 
 

--- a/app/db/models/__init__.py
+++ b/app/db/models/__init__.py
@@ -2,6 +2,7 @@ from .ai_analysis_snapshot import AIAnalysisSnapshot
 from .base import Base
 from .daily_plan import DailyPlan
 from .expense import Expense
+from .goal import Goal
 from .mood import Mood
 from .subscription import Subscription
 from .transaction import Transaction
@@ -20,4 +21,5 @@ __all__ = [
     "AIAnalysisSnapshot",
     "Expense",
     "Mood",
+    "Goal",
 ]

--- a/app/db/models/goal.py
+++ b/app/db/models/goal.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from .base import Base
+
+
+class Goal(Base):
+    __tablename__ = "goals"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    title = Column(String, nullable=False)
+    target_amount = Column(Numeric, nullable=False)
+    saved_amount = Column(Numeric, nullable=False, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/db/models/user.py
+++ b/app/db/models/user.py
@@ -1,9 +1,11 @@
-
 import uuid
 from datetime import datetime
-from sqlalchemy import Column, String, DateTime, Boolean, Numeric
+
+from sqlalchemy import Boolean, Column, DateTime, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID
+
 from .base import Base
+
 
 class User(Base):
     __tablename__ = "users"
@@ -13,4 +15,5 @@ class User(Base):
     country = Column(String(2), default="US")
     annual_income = Column(Numeric, default=0)
     is_premium = Column(Boolean, default=False)
+    premium_until = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,9 @@ from fastapi_limiter.depends import RateLimiter
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 
+from app.api.ai.routes import router as ai_router
 from app.api.analytics.routes import router as analytics_router
+from app.api.assistant_chat_api import router as assistant_chat_router
 
 # New style routers from subdirectories
 from app.api.auth.routes import router as auth_router
@@ -33,6 +35,7 @@ from app.api.calendar_api_redistribute import router as redistribute_router
 from app.api.calendar_api_sql import router as calendar_router
 from app.api.calendar_api_summary import router as summary_router
 from app.api.challenge.routes import router as challenge_router
+from app.api.challenge_progress_api import router as challenge_progress_router
 from app.api.checkpoint.routes import router as checkpoint_router
 from app.api.cluster.routes import router as cluster_router
 from app.api.cohort.routes import router as cohort_router
@@ -41,6 +44,7 @@ from app.api.drift.routes import router as drift_router
 from app.api.expense.routes import router as expense_router
 from app.api.financial.routes import router as financial_router
 from app.api.goal.routes import router as goal_router
+from app.api.goals.routes import router as goals_crud_router
 from app.api.iap.routes import router as iap_router
 from app.api.ocr_api import router as ocr_router
 from app.api.ocr_google_api import router as ocr_google_router
@@ -123,14 +127,18 @@ private_routers_list = [
     (users_router, "/api/users", ["Users"]),
     (calendar_router, "/api/calendar", ["Calendar"]),
     (challenge_router, "/api/challenges", ["Challenges"]),
+    (challenge_progress_router, "/api/challenge-progress", ["ChallengeProgress"]),
     (expense_router, "/api/expenses", ["Expenses"]),
     (goal_router, "/api/goals", ["Goals"]),
+    (goals_crud_router, "/api/goals", ["GoalsCRUD"]),
     (plan_router, "/api/plans", ["Plans"]),
     (budget_router, "/api/budgets", ["Budgets"]),
     (analytics_router, "/api/analytics", ["Analytics"]),
     (behavior_router, "/api/behavior", ["Behavior"]),
     (spend_router, "/api/spend", ["Spend"]),
     (style_router, "/api/styles", ["Styles"]),
+    (ai_router, "/api/ai", ["AI"]),
+    (assistant_chat_router, "/api/assistant", ["assistant"]),
     (transactions_router, "/api/transactions", ["Transactions"]),
     (iap_router, "/api/iap", ["IAP"]),
     (referral_router, "/api/referrals", ["Referrals"]),

--- a/app/services/core/engine/expense_tracker.py
+++ b/app/services/core/engine/expense_tracker.py
@@ -1,17 +1,51 @@
-
-from sqlalchemy.orm import Session
 from datetime import date
 from decimal import Decimal
-from app.db.models import Transaction, DailyPlan
+
+from sqlalchemy.orm import Session
+
+from app.db.models import DailyPlan, Transaction
 from app.services.core.engine.calendar_updater import update_day_status
 
-def record_expense(db: Session, user_id: int, day: date, category: str, amount: float, description: str = ""):
+
+def apply_transaction_to_plan(db: Session, txn: Transaction) -> None:
+    """Apply an already saved transaction to the DailyPlan table."""
+    txn_day = txn.spent_at.date()
+
+    plan = (
+        db.query(DailyPlan)
+        .filter_by(user_id=txn.user_id, date=txn_day, category=txn.category)
+        .first()
+    )
+    if plan:
+        plan.spent_amount += txn.amount
+    else:
+        new_plan = DailyPlan(
+            user_id=txn.user_id,
+            date=txn_day,
+            category=txn.category,
+            planned_amount=Decimal("0.00"),
+            spent_amount=txn.amount,
+        )
+        db.add(new_plan)
+
+    db.commit()
+    update_day_status(db, txn.user_id, txn_day)
+
+
+def record_expense(
+    db: Session,
+    user_id: int,
+    day: date,
+    category: str,
+    amount: float,
+    description: str = "",
+):
     txn = Transaction(
         user_id=user_id,
         date=day,
         category=category,
         amount=Decimal(amount),
-        description=description
+        description=description,
     )
     db.add(txn)
 
@@ -28,7 +62,7 @@ def record_expense(db: Session, user_id: int, day: date, category: str, amount: 
             date=day,
             category=category,
             planned_amount=Decimal("0.00"),
-            spent_amount=Decimal(amount)
+            spent_amount=Decimal(amount),
         )
         db.add(new_plan)
 
@@ -40,5 +74,5 @@ def record_expense(db: Session, user_id: int, day: date, category: str, amount: 
         "status": "recorded",
         "date": day.isoformat(),
         "category": category,
-        "amount": float(amount)
+        "amount": float(amount),
     }

--- a/app/tests/test_challenge_progress.py
+++ b/app/tests/test_challenge_progress.py
@@ -1,0 +1,9 @@
+from app.engine.challenge_engine_auto import auto_run_challenge_streak
+
+
+def test_streak_progress_basic():
+    calendar = [{"date": f"2025-01-{i:02d}", "status": {}} for i in range(1, 6)]
+    result = auto_run_challenge_streak(calendar, "u1", {"last_claimed": "2025-01-01"})
+    assert isinstance(result, dict)
+    assert "streak_days" in result
+

--- a/app/tests/test_goal_tracking.py
+++ b/app/tests/test_goal_tracking.py
@@ -1,0 +1,9 @@
+from app.services.core.engine.goal_tracking import calculate_goal_progress
+
+
+def test_goal_progress():
+    goal = {"name": "Trip", "target_amount": 1000}
+    calendar = {i: {"savings": 100} for i in range(1, 6)}
+    result = calculate_goal_progress(goal, calendar)
+    assert result["percent_complete"] == 50.0
+    assert result["status"] == "in_progress"

--- a/app/tests/test_iap.py
+++ b/app/tests/test_iap.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from app.api.iap.services import validate_receipt
+
+
+def test_validate_receipt_expiration():
+    result = validate_receipt("u1", "sample-year-receipt", "ios")
+    assert result["status"] == "valid"
+    assert result["platform"] == "ios"
+    assert isinstance(result["expires_at"], datetime)

--- a/assistant_chat_ui.html
+++ b/assistant_chat_ui.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Assistant Chat</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; }
+    #chat { border: 1px solid #ccc; padding: 1rem; height: 300px; overflow-y: auto; }
+    .msg { margin-bottom: 0.5rem; }
+    .msg.user { text-align: right; }
+  </style>
+</head>
+<body>
+  <div id="chat"></div>
+  <input id="input" type="text" style="width:80%" placeholder="Type your message" />
+  <button id="send">Send</button>
+  <script>
+    const chat = document.getElementById('chat');
+    const input = document.getElementById('input');
+    document.getElementById('send').onclick = async () => {
+      const text = input.value.trim();
+      if (!text) return;
+      addMsg('user', text);
+      input.value = '';
+      const resp = await fetch('/api/assistant/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: text }] })
+      });
+      const data = await resp.json();
+      addMsg('ai', data.data.reply);
+    };
+    function addMsg(role, text) {
+      const div = document.createElement('div');
+      div.className = 'msg ' + role;
+      div.textContent = text;
+      chat.appendChild(div);
+      chat.scrollTop = chat.scrollHeight;
+    }
+  </script>
+</body>
+</html>

--- a/challenge_progress_ui.html
+++ b/challenge_progress_ui.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Challenge Progress</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; }
+    #result { border: 1px solid #ccc; padding: 1rem; min-height: 100px; }
+  </style>
+</head>
+<body>
+  <h2>Streak Challenge Progress</h2>
+  <button id="check">Check Progress</button>
+  <div id="result"></div>
+  <script>
+    document.getElementById('check').onclick = async () => {
+      const sampleCal = Array.from({length: 10}, (_, i) => ({date: `2025-01-${String(i+1).padStart(2,'0')}`, status: {}}));
+      const resp = await fetch('/api/challenge-progress/progress', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ calendar: sampleCal, user_id: 'demo', log_data: {} })
+      });
+      const data = await resp.json();
+      document.getElementById('result').textContent = JSON.stringify(data.data);
+    };
+  </script>
+</body>
+</html>

--- a/goals_ui.html
+++ b/goals_ui.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Goals Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; }
+    li { margin-bottom: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h2>Your Goals</h2>
+  <ul id="list"></ul>
+  <input id="title" placeholder="Goal title" />
+  <input id="amount" type="number" placeholder="Target amount" />
+  <button id="add">Add Goal</button>
+  <script>
+    async function fetchGoals() {
+      const resp = await fetch('/api/goals/');
+      const data = await resp.json();
+      list.innerHTML = '';
+      for (const g of data.data) {
+        const li = document.createElement('li');
+        li.textContent = `${g.title} - target $${g.target_amount}`;
+        list.appendChild(li);
+      }
+    }
+    document.getElementById('add').onclick = async () => {
+      const title = document.getElementById('title').value.trim();
+      const amt = parseFloat(document.getElementById('amount').value);
+      if (!title || isNaN(amt)) return;
+      await fetch('/api/goals/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: title, target_amount: amt })
+      });
+      document.getElementById('title').value = '';
+      document.getElementById('amount').value = '';
+      fetchGoals();
+    };
+    fetchGoals();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ pytest
 pytest-asyncio
 pytest-cov
 
+openai


### PR DESCRIPTION
## Summary
- add `premium_until` column to `User`
- handle receipt validation and subscription persistence in `/api/iap/validate`
- update dummy validation service to return an expiration timestamp
- add a migration for the new column and a unit test for receipt validation

## Testing
- `pre-commit run --files app/api/iap/routes.py app/api/iap/services.py app/db/models/user.py alembic/versions/0004_user_premium_until.py app/tests/test_iap.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6b0a44c08322b6d5471710baedda