### PR TITLE
Add notification route tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Include:
 - Redistribute button
 - Expense history
 - Assistant recommendations
+- Push notifications & email reminders
 
 ---
 
@@ -230,7 +231,7 @@ Include:
 
 - [ ] Assistant dialog with contextual replies
 - [ ] Spending goals per category
-- [ ] Email reminders
+- [x] Email reminders
 - [x] Scheduled redistribution (monthly cron task)
 - [ ] i18n support
 

--- a/app/api/transactions/services.py
+++ b/app/api/transactions/services.py
@@ -1,7 +1,10 @@
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
 
 from app.db.models import Transaction
-from sqlalchemy.orm import Session
-from decimal import Decimal
+from app.services.core.engine.expense_tracker import apply_transaction_to_plan
+
 
 def add_transaction(user_id: str, data, db: Session):
     txn = Transaction(
@@ -9,12 +12,14 @@ def add_transaction(user_id: str, data, db: Session):
         category=data.category,
         amount=Decimal(str(data.amount)),
         currency=data.currency,
-        spent_at=data.spent_at
+        spent_at=data.spent_at,
     )
     db.add(txn)
     db.commit()
     db.refresh(txn)
+    apply_transaction_to_plan(db, txn)
     return txn
+
 
 def list_user_transactions(user_id: str, db: Session):
     return db.query(Transaction).filter(Transaction.user_id == user_id).all()

--- a/app/tests/test_notification_routes.py
+++ b/app/tests/test_notification_routes.py
@@ -1,0 +1,140 @@
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+if isinstance(sys.modules.get("app.db.models"), object) and not hasattr(
+    sys.modules.get("app.db.models"), "PushToken"
+):
+    sys.modules.pop("app.db.models", None)
+    importlib.import_module("app.db.models")
+
+import pytest
+
+from app.api.notifications.routes import register_token, send_test_notification
+from app.api.notifications.schemas import NotificationTest, TokenIn
+from app.db.models import PushToken
+
+
+class DummyDB:
+    def __init__(self, record=None):
+        self.added = []
+        self.committed = False
+        self.refreshed = []
+        self.record = record
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, obj):
+        self.refreshed.append(obj)
+
+    def query(self, model):
+        assert model is PushToken
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self.record
+
+
+class DummyToken:
+    def __init__(self, user_id, token):
+        self.id = "t123"
+        self.user_id = user_id
+        self.token = token
+        self.created_at = None
+
+
+def parse_json(response):
+    return json.loads(response.body.decode())
+
+
+@pytest.mark.asyncio
+async def test_register_token(monkeypatch):
+    monkeypatch.setattr(
+        "app.api.notifications.routes.PushToken",
+        DummyToken,
+    )
+    db = DummyDB()
+    user = SimpleNamespace(id="u1")
+
+    resp = await register_token(TokenIn(token="abc"), db=db, user=user)
+    payload = parse_json(resp)
+
+    assert db.committed
+    assert isinstance(db.added[0], DummyToken)
+    assert payload["success"] is True
+    assert payload["data"]["token"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_send_test_notification(monkeypatch):
+    sent = {}
+
+    def fake_push(user_id, message, token):
+        sent["push"] = (user_id, message, token)
+
+    def fake_email(email, subject, body):
+        sent["email"] = (email, subject, body)
+
+    monkeypatch.setattr(
+        "app.api.notifications.routes.send_push_notification", fake_push
+    )
+    monkeypatch.setattr(
+        "app.api.notifications.routes.send_reminder_email",
+        fake_email,
+    )
+
+    db = DummyDB()
+    user = SimpleNamespace(id="u1", email="u@example.com")
+
+    resp = await send_test_notification(
+        NotificationTest(message="hi", token="tok", email="e@mail.com"),
+        db=db,
+        user=user,
+    )
+    data = parse_json(resp)
+    assert data["data"]["sent"] is True
+    assert sent["push"] == ("u1", "hi", "tok")
+    assert sent["email"] == ("e@mail.com", "Mita Notification", "hi")
+
+
+@pytest.mark.asyncio
+async def test_send_test_notification_fetches_token(monkeypatch):
+    record = DummyToken("u1", "dbtoken")
+    db = DummyDB(record)
+    user = SimpleNamespace(id="u1", email="u@example.com")
+    sent = {}
+    monkeypatch.setattr(
+        "app.api.notifications.routes.send_push_notification",
+        lambda *a, **k: sent.setdefault(
+            "push",
+            (
+                k.get("user_id"),
+                k.get("message"),
+                k.get("token"),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "app.api.notifications.routes.send_reminder_email",
+        lambda *a: sent.setdefault("email", a),
+    )
+    resp = await send_test_notification(
+        NotificationTest(message="hi"),
+        db=db,
+        user=user,
+    )
+    data = parse_json(resp)
+    assert data["data"]["sent"] is True
+    assert sent.get("push") == ("u1", "hi", "dbtoken")
+    assert sent.get("email")[0] == "u@example.com"

--- a/app/tests/test_notification_utils.py
+++ b/app/tests/test_notification_utils.py
@@ -1,0 +1,103 @@
+import pytest
+
+from app.core.config import settings
+from app.services.push_service import send_push_notification
+from app.utils.email_utils import send_reminder_email
+
+
+class DummySMTP:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.logged_in = False
+        self.starttls_called = False
+        self.sent = []
+
+    def starttls(self):
+        self.starttls_called = True
+
+    def login(self, username, password):
+        self.logged_in = True
+
+    def send_message(self, msg):
+        self.sent.append(msg)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_send_push_requires_token():
+    with pytest.raises(ValueError):
+        send_push_notification(user_id=1, message="hi", token=None)
+
+
+def test_send_reminder_email(monkeypatch):
+    dummy = DummySMTP("localhost", 25)
+
+    def smtp(host, port):
+        assert host == ""
+        assert port == 25
+        return dummy
+
+    monkeypatch.setattr("smtplib.SMTP", smtp)
+    send_reminder_email("to@example.com", "Hi", "Body")
+    assert dummy.sent
+
+
+def test_send_push_notification_builds_message(monkeypatch):
+    class DummyMessage:
+        def __init__(self, notification=None, token=None, data=None):
+            self.notification = notification
+            self.token = token
+            self.data = data
+
+    class DummyNotification:
+        def __init__(self, title=None, body=None):
+            self.title = title
+            self.body = body
+
+    sent = {}
+
+    def dummy_send(msg):
+        sent["msg"] = msg
+        return "id-1"
+
+    monkeypatch.setattr(
+        "app.services.push_service.messaging.Message",
+        DummyMessage,
+    )
+    monkeypatch.setattr(
+        "app.services.push_service.messaging.Notification", DummyNotification
+    )
+    monkeypatch.setattr(
+        "app.services.push_service.messaging.send",
+        dummy_send,
+    )
+
+    resp = send_push_notification(user_id=123, message="Hello", token="tok")
+
+    assert resp == {"message_id": "id-1"}
+    assert sent["msg"].token == "tok"
+    assert sent["msg"].notification.body == "Hello"
+
+
+def test_send_reminder_email_with_login(monkeypatch):
+    dummy = DummySMTP("mail.example.com", 587)
+
+    def smtp(host, port):
+        assert host == "mail.example.com"
+        assert port == 587
+        return dummy
+
+    monkeypatch.setattr("smtplib.SMTP", smtp)
+    monkeypatch.setattr(settings, "smtp_host", "mail.example.com")
+    monkeypatch.setattr(settings, "smtp_port", 587)
+    monkeypatch.setattr(settings, "smtp_username", "user")
+    monkeypatch.setattr(settings, "smtp_password", "pass")
+    send_reminder_email("to@example.com", "Hi", "Body")
+    assert dummy.starttls_called
+    assert dummy.logged_in
+    assert dummy.sent

--- a/app/tests/test_transactions_services.py
+++ b/app/tests/test_transactions_services.py
@@ -1,0 +1,68 @@
+import datetime
+import importlib
+import sys
+from types import SimpleNamespace
+
+if isinstance(sys.modules.get("app.db.models"), object) and not hasattr(
+    sys.modules.get("app.db.models"), "Transaction"
+):
+    # restore real models module if previous tests replaced it
+    sys.modules.pop("app.db.models", None)
+    importlib.import_module("app.db.models")
+
+from app.api.transactions.services import add_transaction
+
+
+class DummyDB:
+    def __init__(self):
+        self.added = []
+        self.committed = False
+        self.refreshed = []
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, obj):
+        self.refreshed.append(obj)
+
+
+class DummyTxn:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def test_add_transaction_triggers_plan(monkeypatch):
+    created = {}
+
+    def dummy_txn(**kw):
+        t = DummyTxn(**kw)
+        created["txn"] = t
+        return t
+
+    monkeypatch.setattr("app.api.transactions.services.Transaction", dummy_txn)
+
+    called = {}
+
+    def dummy_apply(db, txn):
+        called["args"] = (db, txn)
+
+    monkeypatch.setattr(
+        "app.api.transactions.services.apply_transaction_to_plan", dummy_apply
+    )
+
+    db = DummyDB()
+    data = SimpleNamespace(
+        category="food",
+        amount=12.5,
+        currency="USD",
+        spent_at=datetime.datetime(2025, 1, 1),
+    )
+
+    result = add_transaction("u1", data, db)
+
+    assert result is created["txn"]
+    assert called["args"] == (db, created["txn"])
+    assert db.committed


### PR DESCRIPTION
## Summary
- cover register_token and send_test_notification routes
- handle previous monkeypatches when importing models

## Testing
- `pre-commit run --files app/tests/test_notification_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684de0e679588322be3af3c39fc75897