### PR TITLE
Remove AI chat endpoint

### DIFF
--- a/app/agent/gpt_agent_service.py
+++ b/app/agent/gpt_agent_service.py
@@ -1,4 +1,4 @@
-"""GPTAgentService for handling user conversations via OpenAI Chat API."""
+"""GPTAgentService for analysing financial data using OpenAI."""
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
@@ -6,7 +6,7 @@ from openai import OpenAIError
 
 
 class GPTAgentService:
-    """Service that uses OpenAI's GPT models to offer financial advice."""
+    """Use OpenAI to derive insights for analytics and notifications."""
 
     def __init__(self, api_key: str, model: str = "gpt-4o"):
         """
@@ -25,13 +25,7 @@ class GPTAgentService:
         )
 
     def ask(self, user_messages: list[ChatCompletionMessageParam]) -> str:
-        """
-        Send user messages to OpenAI and get the assistant's reply.
-
-        :param user_messages: list of message dicts:
-            [{'role': 'user', 'content': '...'}, ...]
-        :return: The assistant's reply as a string.
-        """
+        """Send prompts to OpenAI and return the generated advice."""
         try:
             messages = [
                 {"role": "system", "content": self.system_prompt}

--- a/app/engine/agent/gpt_agent_service.py
+++ b/app/engine/agent/gpt_agent_service.py
@@ -5,9 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 class GPTAgentService:
-    """
-    A service that communicates with OpenAI's GPT models to provide financial advice.
-    """
+    """Service for analytics and notification generation via OpenAI."""
 
     def __init__(self, api_key: str, model: str = "gpt-4o"):
         """
@@ -26,12 +24,7 @@ class GPTAgentService:
         )
 
     def ask(self, user_messages: list) -> str:
-        """
-        Send user messages to OpenAI and get the assistant's reply.
-
-        :param user_messages: List of message dicts: [{'role': 'user', 'content': '...'}, ...]
-        :return: The assistant's reply as a string.
-        """
+        """Send prompts to OpenAI and return generated advice."""
         try:
             messages = [{"role": "system", "content": self.system_prompt}] + user_messages
             response = openai.ChatCompletion.create(

--- a/app/tests/test_transactions_budget_sync.py
+++ b/app/tests/test_transactions_budget_sync.py
@@ -1,0 +1,53 @@
+import datetime
+from types import SimpleNamespace
+from decimal import Decimal
+
+from app.api.transactions.services import add_transaction
+
+
+class DummyDB:
+    def __init__(self):
+        self.committed = False
+        self.added = []
+        self.refreshed = []
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, obj):
+        self.refreshed.append(obj)
+
+
+class DummyTxn:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def test_add_transaction_records_expense(monkeypatch):
+    monkeypatch.setattr("app.api.transactions.services.Transaction", DummyTxn)
+    spent = {"amount": Decimal("0")}
+
+    def fake_apply(db, txn):
+        spent["amount"] += txn.amount
+
+    monkeypatch.setattr(
+        "app.api.transactions.services.apply_transaction_to_plan",
+        fake_apply,
+    )
+
+    db = DummyDB()
+    data = SimpleNamespace(
+        category="food",
+        amount=12.5,
+        currency="USD",
+        spent_at=datetime.datetime(2025, 1, 1),
+    )
+
+    add_transaction("u1", data, db)
+
+    # Daily plan should be updated once with the transaction amount
+    assert spent["amount"] == Decimal("12.5")
+    assert db.committed


### PR DESCRIPTION
## Summary
- remove the `/assistant/chat` API and related tests
- update GPT agent service docs to clarify analytics use
- keep budget update test for transactions

## Testing
- `pytest -q`
- `pytest app/tests/test_transactions_budget_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6850826881a08322bff63b85aa1f9429