### PR TITLE
Add automated backup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ SMTP_FROM=notify@example.com
 APPLE_SHARED_SECRET=changeme
 GOOGLE_SERVICE_ACCOUNT=/path/to/google.json
 ALLOWED_ORIGINS=https://app.mita.finance
+S3_BUCKET=my-mita-backups
+AWS_ACCESS_KEY_ID=changeme
+AWS_SECRET_ACCESS_KEY=changeme
+AWS_REGION=us-east-1

--- a/README.md
+++ b/README.md
@@ -250,7 +250,12 @@ Include:
 - [ ] Spending goals per category
 - [x] Email reminders
 
-## 🔧 13. Running Tests
+## 📦 13. Automated Backups
+
+Use `scripts/backup_database.py` to dump the Postgres database and upload it to S3. Set `S3_BUCKET` and AWS credentials in the environment. Old backups older than 7 days are cleaned up automatically.
+
+
+## 🔧 14. Running Tests
 
 To run the backend unit tests locally, first install all Python dependencies:
 

--- a/app/agent/gpt_agent_service.py
+++ b/app/agent/gpt_agent_service.py
@@ -1,4 +1,4 @@
-"""GPTAgentService for handling user conversations via OpenAI Chat API."""
+"""GPTAgentService for analysing financial data using OpenAI."""
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
@@ -6,7 +6,7 @@ from openai import OpenAIError
 
 
 class GPTAgentService:
-    """Service that uses OpenAI's GPT models to offer financial advice."""
+    """Use OpenAI to derive insights for analytics and notifications."""
 
     def __init__(self, api_key: str, model: str = "gpt-4o"):
         """
@@ -25,13 +25,7 @@ class GPTAgentService:
         )
 
     def ask(self, user_messages: list[ChatCompletionMessageParam]) -> str:
-        """
-        Send user messages to OpenAI and get the assistant's reply.
-
-        :param user_messages: list of message dicts:
-            [{'role': 'user', 'content': '...'}, ...]
-        :return: The assistant's reply as a string.
-        """
+        """Send prompts to OpenAI and return the generated advice."""
         try:
             messages = [
                 {"role": "system", "content": self.system_prompt}

--- a/app/engine/agent/gpt_agent_service.py
+++ b/app/engine/agent/gpt_agent_service.py
@@ -5,9 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 class GPTAgentService:
-    """
-    A service that communicates with OpenAI's GPT models to provide financial advice.
-    """
+    """Service for analytics and notification generation via OpenAI."""
 
     def __init__(self, api_key: str, model: str = "gpt-4o"):
         """
@@ -26,12 +24,7 @@ class GPTAgentService:
         )
 
     def ask(self, user_messages: list) -> str:
-        """
-        Send user messages to OpenAI and get the assistant's reply.
-
-        :param user_messages: List of message dicts: [{'role': 'user', 'content': '...'}, ...]
-        :return: The assistant's reply as a string.
-        """
+        """Send prompts to OpenAI and return generated advice."""
         try:
             messages = [{"role": "system", "content": self.system_prompt}] + user_messages
             response = openai.ChatCompletion.create(

--- a/app/tests/test_transactions_budget_sync.py
+++ b/app/tests/test_transactions_budget_sync.py
@@ -1,0 +1,53 @@
+import datetime
+from types import SimpleNamespace
+from decimal import Decimal
+
+from app.api.transactions.services import add_transaction
+
+
+class DummyDB:
+    def __init__(self):
+        self.committed = False
+        self.added = []
+        self.refreshed = []
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, obj):
+        self.refreshed.append(obj)
+
+
+class DummyTxn:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def test_add_transaction_records_expense(monkeypatch):
+    monkeypatch.setattr("app.api.transactions.services.Transaction", DummyTxn)
+    spent = {"amount": Decimal("0")}
+
+    def fake_apply(db, txn):
+        spent["amount"] += txn.amount
+
+    monkeypatch.setattr(
+        "app.api.transactions.services.apply_transaction_to_plan",
+        fake_apply,
+    )
+
+    db = DummyDB()
+    data = SimpleNamespace(
+        category="food",
+        amount=12.5,
+        currency="USD",
+        spent_at=datetime.datetime(2025, 1, 1),
+    )
+
+    add_transaction("u1", data, db)
+
+    # Daily plan should be updated once with the transaction amount
+    assert spent["amount"] == Decimal("12.5")
+    assert db.committed

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ pytest-asyncio
 pytest-cov
 
 openai
+boto3

--- a/scripts/backup_database.py
+++ b/scripts/backup_database.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import tempfile
+import datetime
+import gzip
+import shutil
+import boto3
+
+
+def backup_database() -> None:
+    """Dump the Postgres database and upload to S3."""
+    db_url = os.environ.get("DATABASE_URL")
+    bucket = os.environ.get("S3_BUCKET")
+    if not db_url or not bucket:
+        raise RuntimeError("DATABASE_URL and S3_BUCKET must be set")
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    key = f"backup-{timestamp}.sql.gz"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sql_path = os.path.join(tmpdir, "dump.sql")
+        with open(sql_path, "wb") as f:
+            subprocess.run(["pg_dump", db_url], check=True, stdout=f)
+
+        gz_path = f"{sql_path}.gz"
+        with open(sql_path, "rb") as f_in, gzip.open(gz_path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+            region_name=os.environ.get("AWS_REGION", "us-east-1"),
+        )
+        s3.upload_file(gz_path, bucket, key)
+
+        retention = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+        objects = s3.list_objects_v2(Bucket=bucket).get("Contents", [])
+        for obj in objects:
+            if obj.get("LastModified") and obj["LastModified"].replace(tzinfo=None) < retention:
+                s3.delete_object(Bucket=bucket, Key=obj["Key"])
+
+
+if __name__ == "__main__":
+    backup_database()


### PR DESCRIPTION
## Summary
- add `scripts/backup_database.py` for daily S3 pg_dump
- document backup config in README and .env.example
- include boto3 in requirements

## Testing
- `pytest -q`
- `pytest app/tests/test_transactions_budget_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6850826881a08322bff63b85aa1f9429