### PR TITLE
Add background worker system

### DIFF
--- a/app/api/insights/__init__.py
+++ b/app/api/insights/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/app/api/insights/routes.py
+++ b/app/api/insights/routes.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
+from app.core.session import get_db
+from app.db.models import BudgetAdvice
+from app.utils.response_wrapper import success_response
+from .schemas import AdviceOut
+
+router = APIRouter(prefix="", tags=["insights"])
+
+
+@router.get("/", response_model=AdviceOut | None)
+async def latest_insight(
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    advice = (
+        db.query(BudgetAdvice)
+        .filter(BudgetAdvice.user_id == user.id)
+        .order_by(BudgetAdvice.date.desc())
+        .first()
+    )
+    data = (
+        AdviceOut.model_validate(advice).model_dump(mode="json") if advice else None
+    )
+    return success_response(data)
+
+
+@router.get("/history", response_model=list[AdviceOut])
+async def insight_history(
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    items = (
+        db.query(BudgetAdvice)
+        .filter(BudgetAdvice.user_id == user.id)
+        .order_by(BudgetAdvice.date.desc())
+        .all()
+    )
+    data = [AdviceOut.model_validate(it).model_dump(mode="json") for it in items]
+    return success_response(data)

--- a/app/api/insights/schemas.py
+++ b/app/api/insights/schemas.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class AdviceOut(BaseModel):
+    id: str
+    date: datetime
+    type: str
+    text: str
+
+    class Config:
+        orm_mode = True

--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,7 @@ from app.api.plan.routes import router as plan_router
 from app.api.referral.routes import router as referral_router
 from app.api.spend.routes import router as spend_router
 from app.api.style.routes import router as style_router
+from app.api.insights.routes import router as insights_router
 from app.api.transactions.routes import router as transactions_router
 from app.api.transactions.routes_background import router as transactions_v2_router
 from app.api.users.routes import router as users_router
@@ -117,6 +118,7 @@ private_routers_list = [
     (behavior_router, "/api/behavior", ["Behavior"]),
     (spend_router, "/api/spend", ["Spend"]),
     (style_router, "/api/styles", ["Styles"]),
+    (insights_router, "/api/insights", ["Insights"]),
     (ai_router, "/api/ai", ["AI"]),
     (transactions_router, "/api/transactions", ["Transactions"]),
     (transactions_v2_router, "/api/transactions/v2", ["Transactions"]),

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,25 @@
+import os
+from redis import Redis
+from rq import Queue
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+queue = Queue("default", connection=Redis.from_url(redis_url))
+
+
+def enqueue_daily_advice() -> None:
+    from app.services.core.engine.cron_task_ai_advice import run_ai_advice_batch
+    queue.enqueue(run_ai_advice_batch)
+
+
+def enqueue_monthly_redistribution() -> None:
+    from app.services.core.engine.cron_task_budget_redistribution import (
+        run_budget_redistribution_batch,
+    )
+    queue.enqueue(run_budget_redistribution_batch)
+
+
+def enqueue_subscription_refresh() -> None:
+    from app.services.core.engine.cron_task_subscription_refresh import (
+        refresh_premium_status,
+    )
+    queue.enqueue(refresh_premium_status)

--- a/app/tests/test_insights_api.py
+++ b/app/tests/test_insights_api.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("FIREBASE_JSON", "{}")
+
+dummy = types.ModuleType("firebase_admin")
+dummy._apps = []
+dummy.credentials = types.SimpleNamespace(ApplicationDefault=lambda: None)
+dummy.initialize_app = lambda cred=None: None
+dummy.firestore = types.SimpleNamespace(
+    client=lambda: types.SimpleNamespace(collection=lambda *a, **k: None)
+)
+dummy.messaging = types.SimpleNamespace(Message=None, Notification=None, send=lambda *a, **k: None)
+sys.modules["firebase_admin"] = dummy
+sys.modules["firebase_admin.credentials"] = dummy.credentials
+sys.modules["firebase_admin.firestore"] = dummy.firestore
+sys.modules["firebase_admin.messaging"] = dummy.messaging
+
+from app.main import app
+import app.api.insights.routes as insights_routes
+
+
+class DummyQuery:
+    def __init__(self, item):
+        self.item = item
+
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def first(self):
+        return self.item
+
+    def all(self):
+        return [self.item] if self.item else []
+
+
+class DummyDB:
+    def __init__(self, item):
+        self.item = item
+
+    def query(self, model):
+        return DummyQuery(self.item)
+
+
+def test_latest_insight(monkeypatch):
+    advice = {"id": "a1", "date": "2025-01-01", "type": "risk", "text": "be careful"}
+
+    def dummy_get_db():
+        yield DummyDB(advice)
+
+    app.dependency_overrides[insights_routes.get_db] = dummy_get_db
+    app.dependency_overrides[insights_routes.get_current_user] = lambda: SimpleNamespace(id="u1")
+
+    client = TestClient(app)
+    resp = client.get("/api/insights/")
+    app.dependency_overrides = {}
+    assert resp.status_code == 200
+    assert resp.json()["data"]["text"] == "be careful"
+
+
+def test_insight_history(monkeypatch):
+    advice = {"id": "a1", "date": "2025-01-01", "type": "risk", "text": "be careful"}
+
+    def dummy_get_db():
+        yield DummyDB(advice)
+
+    app.dependency_overrides[insights_routes.get_db] = dummy_get_db
+    app.dependency_overrides[insights_routes.get_current_user] = lambda: SimpleNamespace(id="u1")
+
+    client = TestClient(app)
+    resp = client.get("/api/insights/history")
+    app.dependency_overrides = {}
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["id"] == "a1"

--- a/app/tests/test_tasks.py
+++ b/app/tests/test_tasks.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+from app import tasks
+
+
+def test_enqueue_jobs(monkeypatch):
+    calls = []
+
+    class DummyQueue:
+        def enqueue(self, func):
+            calls.append(func.__name__)
+
+    monkeypatch.setattr(tasks, "queue", DummyQueue())
+    tasks.enqueue_daily_advice()
+    tasks.enqueue_monthly_redistribution()
+    tasks.enqueue_subscription_refresh()
+
+    assert calls == [
+        "run_ai_advice_batch",
+        "run_budget_redistribution_batch",
+        "refresh_premium_status",
+    ]

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,0 +1,10 @@
+import os
+from redis import Redis
+from rq import Worker, Queue, Connection
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+conn = Redis.from_url(redis_url)
+
+with Connection(conn):
+    worker = Worker(["default"])
+    worker.work()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,3 +46,24 @@ services:
       - --port
       - "8000"
 
+  worker:
+    build: .
+    command: python -m app.worker
+    environment:
+      PYTHONPATH: "/code"
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - redis
+      - db
+    restart: unless-stopped
+
+  scheduler:
+    build: .
+    command: python scripts/rq_scheduler.py
+    environment:
+      PYTHONPATH: "/code"
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - redis
+    restart: unless-stopped
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ pytest-cov
 
 openai
 boto3
+rq
+rq-scheduler

--- a/scripts/rq_scheduler.py
+++ b/scripts/rq_scheduler.py
@@ -1,0 +1,43 @@
+import os
+from redis import Redis
+from rq_scheduler import Scheduler
+from datetime import datetime
+from app.tasks import (
+    enqueue_daily_advice,
+    enqueue_monthly_redistribution,
+    enqueue_subscription_refresh,
+)
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+conn = Redis.from_url(redis_url)
+scheduler = Scheduler(queue_name="default", connection=conn)
+
+# Clear existing jobs on startup
+scheduler.cancel_all()
+
+# Daily advisory push at 08:00 UTC
+scheduler.cron(
+    "0 8 * * *",
+    func=enqueue_daily_advice,
+    repeat=None,
+    queue_name="default",
+)
+
+# Monthly redistribution on the 1st at 01:00 UTC
+scheduler.cron(
+    "0 1 1 * *",
+    func=enqueue_monthly_redistribution,
+    repeat=None,
+    queue_name="default",
+)
+
+# Subscription refresh every day at 02:00 UTC
+scheduler.cron(
+    "0 2 * * *",
+    func=enqueue_subscription_refresh,
+    repeat=None,
+    queue_name="default",
+)
+
+if __name__ == "__main__":
+    scheduler.run()


### PR DESCRIPTION
## Summary
- introduce RQ queue tasks for scheduled jobs
- add worker and scheduler containers to docker-compose
- include rq and rq-scheduler dependencies
- test that tasks enqueue proper jobs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851da3bd2688322839f63c463f4924a