### PR TITLE
Add premium subscription screen

### DIFF
--- a/app/api/insights/__init__.py
+++ b/app/api/insights/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/app/api/insights/routes.py
+++ b/app/api/insights/routes.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
+from app.core.session import get_db
+from app.db.models import BudgetAdvice
+from app.utils.response_wrapper import success_response
+from .schemas import AdviceOut
+
+router = APIRouter(prefix="", tags=["insights"])
+
+
+@router.get("/", response_model=AdviceOut | None)
+async def latest_insight(
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    advice = (
+        db.query(BudgetAdvice)
+        .filter(BudgetAdvice.user_id == user.id)
+        .order_by(BudgetAdvice.date.desc())
+        .first()
+    )
+    data = (
+        AdviceOut.model_validate(advice).model_dump(mode="json") if advice else None
+    )
+    return success_response(data)
+
+
+@router.get("/history", response_model=list[AdviceOut])
+async def insight_history(
+    user=Depends(get_current_user),  # noqa: B008
+    db: Session = Depends(get_db),  # noqa: B008
+):
+    items = (
+        db.query(BudgetAdvice)
+        .filter(BudgetAdvice.user_id == user.id)
+        .order_by(BudgetAdvice.date.desc())
+        .all()
+    )
+    data = [AdviceOut.model_validate(it).model_dump(mode="json") for it in items]
+    return success_response(data)

--- a/app/api/insights/schemas.py
+++ b/app/api/insights/schemas.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class AdviceOut(BaseModel):
+    id: str
+    date: datetime
+    type: str
+    text: str
+
+    class Config:
+        orm_mode = True

--- a/app/api/users/routes.py
+++ b/app/api/users/routes.py
@@ -20,6 +20,10 @@ async def get_profile(current_user=Depends(get_current_user)):
             "country": current_user.country,
             "created_at": current_user.created_at.isoformat(),
             "timezone": current_user.timezone,
+            "is_premium": current_user.is_premium,
+            "premium_until": current_user.premium_until.isoformat()
+            if current_user.premium_until
+            else None,
         }
     )
 
@@ -39,6 +43,8 @@ async def update_profile(
             "email": user.email,
             "country": user.country,
             "timezone": user.timezone,
+            "is_premium": user.is_premium,
+            "premium_until": user.premium_until.isoformat() if user.premium_until else None,
             "updated_at": user.updated_at.isoformat(),
         }
     )

--- a/app/api/users/schemas.py
+++ b/app/api/users/schemas.py
@@ -10,6 +10,8 @@ class UserProfileOut(BaseModel):
     country: str
     created_at: datetime
     timezone: str
+    is_premium: bool
+    premium_until: Optional[datetime] = None
 
 
 class UserUpdateIn(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,7 @@ from app.api.plan.routes import router as plan_router
 from app.api.referral.routes import router as referral_router
 from app.api.spend.routes import router as spend_router
 from app.api.style.routes import router as style_router
+from app.api.insights.routes import router as insights_router
 from app.api.transactions.routes import router as transactions_router
 from app.api.transactions.routes_background import router as transactions_v2_router
 from app.api.users.routes import router as users_router
@@ -117,6 +118,7 @@ private_routers_list = [
     (behavior_router, "/api/behavior", ["Behavior"]),
     (spend_router, "/api/spend", ["Spend"]),
     (style_router, "/api/styles", ["Styles"]),
+    (insights_router, "/api/insights", ["Insights"]),
     (ai_router, "/api/ai", ["AI"]),
     (transactions_router, "/api/transactions", ["Transactions"]),
     (transactions_v2_router, "/api/transactions/v2", ["Transactions"]),

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,25 @@
+import os
+from redis import Redis
+from rq import Queue
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+queue = Queue("default", connection=Redis.from_url(redis_url))
+
+
+def enqueue_daily_advice() -> None:
+    from app.services.core.engine.cron_task_ai_advice import run_ai_advice_batch
+    queue.enqueue(run_ai_advice_batch)
+
+
+def enqueue_monthly_redistribution() -> None:
+    from app.services.core.engine.cron_task_budget_redistribution import (
+        run_budget_redistribution_batch,
+    )
+    queue.enqueue(run_budget_redistribution_batch)
+
+
+def enqueue_subscription_refresh() -> None:
+    from app.services.core.engine.cron_task_subscription_refresh import (
+        refresh_premium_status,
+    )
+    queue.enqueue(refresh_premium_status)

--- a/app/tests/test_insights_api.py
+++ b/app/tests/test_insights_api.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("FIREBASE_JSON", "{}")
+
+dummy = types.ModuleType("firebase_admin")
+dummy._apps = []
+dummy.credentials = types.SimpleNamespace(ApplicationDefault=lambda: None)
+dummy.initialize_app = lambda cred=None: None
+dummy.firestore = types.SimpleNamespace(
+    client=lambda: types.SimpleNamespace(collection=lambda *a, **k: None)
+)
+dummy.messaging = types.SimpleNamespace(Message=None, Notification=None, send=lambda *a, **k: None)
+sys.modules["firebase_admin"] = dummy
+sys.modules["firebase_admin.credentials"] = dummy.credentials
+sys.modules["firebase_admin.firestore"] = dummy.firestore
+sys.modules["firebase_admin.messaging"] = dummy.messaging
+
+from app.main import app
+import app.api.insights.routes as insights_routes
+
+
+class DummyQuery:
+    def __init__(self, item):
+        self.item = item
+
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def first(self):
+        return self.item
+
+    def all(self):
+        return [self.item] if self.item else []
+
+
+class DummyDB:
+    def __init__(self, item):
+        self.item = item
+
+    def query(self, model):
+        return DummyQuery(self.item)
+
+
+def test_latest_insight(monkeypatch):
+    advice = {"id": "a1", "date": "2025-01-01", "type": "risk", "text": "be careful"}
+
+    def dummy_get_db():
+        yield DummyDB(advice)
+
+    app.dependency_overrides[insights_routes.get_db] = dummy_get_db
+    app.dependency_overrides[insights_routes.get_current_user] = lambda: SimpleNamespace(id="u1")
+
+    client = TestClient(app)
+    resp = client.get("/api/insights/")
+    app.dependency_overrides = {}
+    assert resp.status_code == 200
+    assert resp.json()["data"]["text"] == "be careful"
+
+
+def test_insight_history(monkeypatch):
+    advice = {"id": "a1", "date": "2025-01-01", "type": "risk", "text": "be careful"}
+
+    def dummy_get_db():
+        yield DummyDB(advice)
+
+    app.dependency_overrides[insights_routes.get_db] = dummy_get_db
+    app.dependency_overrides[insights_routes.get_current_user] = lambda: SimpleNamespace(id="u1")
+
+    client = TestClient(app)
+    resp = client.get("/api/insights/history")
+    app.dependency_overrides = {}
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["id"] == "a1"

--- a/app/tests/test_no_cyrillic.py
+++ b/app/tests/test_no_cyrillic.py
@@ -1,0 +1,16 @@
+import os
+import re
+
+CYRILLIC_RE = re.compile('[\u0400-\u04FF]')
+
+def test_no_cyrillic_characters():
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    for root, _, files in os.walk(base_dir):
+        if root.startswith(os.path.join(base_dir, 'docs', 'legacy')):
+            continue
+        for name in files:
+            if name.endswith('.py') or name.endswith('.md') or name.endswith('.yaml') or name.endswith('.yml') or name.endswith('.txt'):
+                path = os.path.join(root, name)
+                with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+                    content = f.read()
+                    assert not CYRILLIC_RE.search(content), f'Cyrillic characters found in {path}'

--- a/app/tests/test_tasks.py
+++ b/app/tests/test_tasks.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+from app import tasks
+
+
+def test_enqueue_jobs(monkeypatch):
+    calls = []
+
+    class DummyQueue:
+        def enqueue(self, func):
+            calls.append(func.__name__)
+
+    monkeypatch.setattr(tasks, "queue", DummyQueue())
+    tasks.enqueue_daily_advice()
+    tasks.enqueue_monthly_redistribution()
+    tasks.enqueue_subscription_refresh()
+
+    assert calls == [
+        "run_ai_advice_batch",
+        "run_budget_redistribution_batch",
+        "refresh_premium_status",
+    ]

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,0 +1,10 @@
+import os
+from redis import Redis
+from rq import Worker, Queue, Connection
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+conn = Redis.from_url(redis_url)
+
+with Connection(conn):
+    worker = Worker(["default"])
+    worker.work()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,3 +46,24 @@ services:
       - --port
       - "8000"
 
+  worker:
+    build: .
+    command: python -m app.worker
+    environment:
+      PYTHONPATH: "/code"
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - redis
+      - db
+    restart: unless-stopped
+
+  scheduler:
+    build: .
+    command: python scripts/rq_scheduler.py
+    environment:
+      PYTHONPATH: "/code"
+      REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - redis
+    restart: unless-stopped
+

--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -10,6 +10,11 @@ import 'screens/add_expense_screen.dart';
 import 'screens/calendar_screen.dart';
 import 'screens/main_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'screens/advice_history_screen.dart';
+import 'screens/premium_subscription_screen.dart';
+import 'services/api_service.dart';
 
 import 'screens/welcome_screen.dart';
 import 'screens/login_screen.dart';
@@ -21,7 +26,26 @@ import 'screens/onboarding_habits_screen.dart';
 import 'screens/onboarding_motivation_screen.dart';
 import 'screens/onboarding_finish_screen.dart';
 
-void main() {
+Future<void> _initFirebase() async {
+  await Firebase.initializeApp();
+  await FirebaseMessaging.instance.requestPermission();
+  final token = await FirebaseMessaging.instance.getToken();
+  if (token != null) {
+    final api = ApiService();
+    await api.registerPushToken(token);
+  }
+  FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+    navigatorKey.currentState?.push(
+      MaterialPageRoute(builder: (_) => const AdviceHistoryScreen()),
+    );
+  });
+}
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await _initFirebase();
   runApp(const MITAApp());
 }
 
@@ -31,6 +55,7 @@ class MITAApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: navigatorKey,
       title: 'MITA',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
@@ -51,6 +76,7 @@ class MITAApp extends StatelessWidget {
         '/onboarding_habits': (context) => const OnboardingHabitsScreen(),
         '/onboarding_motivation': (context) => const OnboardingMotivationScreen(),
         '/onboarding_finish': (context) => const OnboardingFinishScreen(),
+        '/premium': (context) => const PremiumSubscriptionScreen(),
       },
     );
   }

--- a/mobile_app/lib/screens/advice_history_screen.dart
+++ b/mobile_app/lib/screens/advice_history_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../services/api_service.dart';
+
+class AdviceHistoryScreen extends StatefulWidget {
+  const AdviceHistoryScreen({Key? key}) : super(key: key);
+
+  @override
+  State<AdviceHistoryScreen> createState() => _AdviceHistoryScreenState();
+}
+
+class _AdviceHistoryScreenState extends State<AdviceHistoryScreen> {
+  final ApiService _apiService = ApiService();
+  bool _loading = true;
+  List<dynamic> _items = [];
+
+  @override
+  void initState() {
+    super.initState();
+    fetchHistory();
+  }
+
+  Future<void> fetchHistory() async {
+    try {
+      final data = await _apiService.getAdviceHistory();
+      setState(() {
+        _items = data;
+        _loading = false;
+      });
+    } catch (e) {
+      setState(() => _loading = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to load history: $e')),  # placeholder
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Advice History'),
+        backgroundColor: const Color(0xFFFFF9F0),
+        iconTheme: const IconThemeData(color: Color(0xFF193C57)),
+        centerTitle: true,
+        elevation: 0,
+      ),
+      backgroundColor: const Color(0xFFFFF9F0),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: _items.length,
+              itemBuilder: (_, i) {
+                final item = _items[i] as Map<String, dynamic>;
+                final date = DateFormat.yMMMd().format(DateTime.parse(item['date'] as String));
+                return ListTile(
+                  title: Text(item['text'] as String),
+                  subtitle: Text(date),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/mobile_app/lib/screens/main_screen.dart
+++ b/mobile_app/lib/screens/main_screen.dart
@@ -1,6 +1,7 @@
 
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import 'advice_history_screen.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -12,6 +13,7 @@ class MainScreen extends StatefulWidget {
 class _MainScreenState extends State<MainScreen> {
   final ApiService _apiService = ApiService();
   Map<String, dynamic>? dashboardData;
+  Map<String, dynamic>? latestAdvice;
   bool isLoading = true;
   String? error;
 
@@ -24,9 +26,11 @@ class _MainScreenState extends State<MainScreen> {
   Future<void> fetchDashboardData() async {
     try {
       final data = await _apiService.getDashboard();
+      final advice = await _apiService.getLatestAdvice();
       if (!mounted) return;
       setState(() {
         dashboardData = data;
+        latestAdvice = advice;
         isLoading = false;
       });
     } catch (e) {
@@ -66,6 +70,8 @@ class _MainScreenState extends State<MainScreen> {
                         _buildBudgetTargets(),
                         const SizedBox(height: 20),
                         _buildMiniCalendar(),
+                        const SizedBox(height: 20),
+                        _buildInsightsCard(),
                         const SizedBox(height: 20),
                         _buildRecentTransactions(),
                       ],
@@ -174,6 +180,29 @@ class _MainScreenState extends State<MainScreen> {
           }).toList(),
         ),
       ],
+    );
+  }
+
+  Widget _buildInsightsCard() {
+    final text = latestAdvice?['text'] ?? 'No advice yet';
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const AdviceHistoryScreen()),
+        );
+      },
+      child: Card(
+        color: const Color(0xFFE8F0FE),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            text,
+            style: const TextStyle(fontFamily: 'Manrope'),
+          ),
+        ),
+      ),
     );
   }
 

--- a/mobile_app/lib/screens/premium_subscription_screen.dart
+++ b/mobile_app/lib/screens/premium_subscription_screen.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+
+import '../services/api_service.dart';
+
+class PremiumSubscriptionScreen extends StatefulWidget {
+  const PremiumSubscriptionScreen({Key? key}) : super(key: key);
+
+  @override
+  State<PremiumSubscriptionScreen> createState() => _PremiumSubscriptionScreenState();
+}
+
+class _PremiumSubscriptionScreenState extends State<PremiumSubscriptionScreen> {
+  final InAppPurchase _iap = InAppPurchase.instance;
+  final ApiService _api = ApiService();
+  late StreamSubscription<List<PurchaseDetails>> _sub;
+  bool _loading = true;
+  bool _isPremium = false;
+  List<ProductDetails> _products = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    final available = await _iap.isAvailable();
+    if (available) {
+      const ids = {'mita_premium_monthly', 'mita_premium_annual'};
+      final resp = await _iap.queryProductDetails(ids);
+      _products = resp.productDetails;
+      _sub = _iap.purchaseStream.listen(_listenPurchases);
+    }
+    final profile = await _api.getUserProfile();
+    setState(() {
+      _isPremium = profile['data']['is_premium'] as bool? ?? false;
+      _loading = false;
+    });
+  }
+
+  Future<void> _listenPurchases(List<PurchaseDetails> purchases) async {
+    for (var p in purchases) {
+      if (p.status == PurchaseStatus.purchased) {
+        final platform = Theme.of(context).platform == TargetPlatform.iOS ? 'ios' : 'android';
+        await _api.validateReceipt(p.verificationData.serverVerificationData, platform);
+        setState(() => _isPremium = true);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Premium Subscription'),
+        backgroundColor: const Color(0xFFFFF9F0),
+        iconTheme: const IconThemeData(color: Color(0xFF193C57)),
+        centerTitle: true,
+      ),
+      backgroundColor: const Color(0xFFFFF9F0),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: _isPremium
+            ? const Center(child: Text('You are a premium user!'))
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Upgrade to access premium features',
+                    style: TextStyle(fontFamily: 'Manrope', fontSize: 16),
+                  ),
+                  const SizedBox(height: 20),
+                  ..._products.map(
+                    (p) => ElevatedButton(
+                      onPressed: () {
+                        final param = PurchaseParam(productDetails: p);
+                        _iap.buyNonConsumable(purchaseParam: param);
+                      },
+                      child: Text('Buy ${p.title} – ${p.price}'),
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/screens/profile_screen.dart
+++ b/mobile_app/lib/screens/profile_screen.dart
@@ -17,6 +17,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   String? _name;
   bool _isLoading = true;
   bool _isSaving = false;
+  bool _isPremium = false;
 
   @override
   void initState() {
@@ -28,8 +29,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
     try {
       final data = await _apiService.getUserProfile();
       setState(() {
-        _email = data['email'];
-        _name = data['name'];
+        final map = data['data'] as Map<String, dynamic>;
+        _email = map['email'] as String?;
+        _name = map['name'] as String?;
+        _isPremium = map['is_premium'] as bool? ?? false;
         _isLoading = false;
       });
     } catch (e) {
@@ -136,6 +139,31 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     ),
 
                     const SizedBox(height: 20),
+                    if (!_isPremium)
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.pushNamed(context, '/premium');
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFF193C57),
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: const Text(
+                          'Upgrade to Premium',
+                          style: TextStyle(
+                            fontFamily: 'Sora',
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+
+                    if (!_isPremium) const SizedBox(height: 20),
+
                     ElevatedButton(
                       onPressed: () async {
                         await _apiService.logout();

--- a/mobile_app/lib/services/api_service.dart
+++ b/mobile_app/lib/services/api_service.dart
@@ -198,6 +198,28 @@ class ApiService {
     return Map<String, dynamic>.from(response.data);
   }
 
+  Future<Map<String, dynamic>?> getLatestAdvice() async {
+    final token = await getToken();
+    final response = await _dio.get(
+      '/api/insights/',
+      options: Options(
+        headers: {'Authorization': 'Bearer $token'},
+      ),
+    );
+    return response.data['data'] as Map<String, dynamic>?;
+  }
+
+  Future<List<dynamic>> getAdviceHistory() async {
+    final token = await getToken();
+    final response = await _dio.get(
+      '/api/insights/history',
+      options: Options(
+        headers: {'Authorization': 'Bearer $token'},
+      ),
+    );
+    return List<dynamic>.from(response.data['data'] as List);
+  }
+
 
   Future<Map<String, dynamic>> getUser() async {
     final token = await getToken();
@@ -277,6 +299,22 @@ class ApiService {
     );
   }
 
+  Future<Map<String, dynamic>> validateReceipt(
+      String receipt, String platform) async {
+    final token = await getToken();
+    final userId = await getUserId();
+    final response = await _dio.post(
+      '/api/iap/validate',
+      data: {
+        'user_id': userId,
+        'receipt': receipt,
+        'platform': platform,
+      },
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
+    );
+    return Map<String, dynamic>.from(response.data['data']);
+  }
+
 
   Future<List<dynamic>> getNotifications() async {
     final token = await getToken();
@@ -340,6 +378,15 @@ class ApiService {
       options: Options(headers: {'Authorization': 'Bearer $token'}),
     );
     return response.data;
+  }
+
+  Future<void> registerPushToken(String token) async {
+    final access = await getToken();
+    await _dio.post(
+      '/api/notifications/register-token',
+      data: {'token': token},
+      options: Options(headers: {'Authorization': 'Bearer $access'}),
+    );
   }
 
   Future<void> logout() async {

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   intl: ^0.18.1
   google_sign_in: ^6.1.5
   fl_chart: ^0.71.0
+  firebase_core: ^2.24.0
+  firebase_messaging: ^14.7.4
+  in_app_purchase: ^3.1.9
 
 dev_dependencies:
   flutter_test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,5 @@ pytest-cov
 
 openai
 boto3
+rq
+rq-scheduler

--- a/scripts/rq_scheduler.py
+++ b/scripts/rq_scheduler.py
@@ -1,0 +1,43 @@
+import os
+from redis import Redis
+from rq_scheduler import Scheduler
+from datetime import datetime
+from app.tasks import (
+    enqueue_daily_advice,
+    enqueue_monthly_redistribution,
+    enqueue_subscription_refresh,
+)
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+conn = Redis.from_url(redis_url)
+scheduler = Scheduler(queue_name="default", connection=conn)
+
+# Clear existing jobs on startup
+scheduler.cancel_all()
+
+# Daily advisory push at 08:00 UTC
+scheduler.cron(
+    "0 8 * * *",
+    func=enqueue_daily_advice,
+    repeat=None,
+    queue_name="default",
+)
+
+# Monthly redistribution on the 1st at 01:00 UTC
+scheduler.cron(
+    "0 1 1 * *",
+    func=enqueue_monthly_redistribution,
+    repeat=None,
+    queue_name="default",
+)
+
+# Subscription refresh every day at 02:00 UTC
+scheduler.cron(
+    "0 2 * * *",
+    func=enqueue_subscription_refresh,
+    repeat=None,
+    queue_name="default",
+)
+
+if __name__ == "__main__":
+    scheduler.run()


### PR DESCRIPTION
## Summary
- extend user profile schema with `is_premium` and `premium_until`
- expose premium status via `/api/users/me`
- add `validateReceipt` API helper
- implement Flutter PremiumSubscriptionScreen and navigation
- show upgrade button in profile screen
- include `in_app_purchase` dependency
- expose insights API routes
- introduce worker and scheduler for periodic jobs
- show latest advice on dashboard
- add unit tests for insights and task queue
- **new**: ensure repository has no Cyrillic text

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851da3bd2688322839f63c463f4924a