### PR TITLE
Add APNs support and mood API

### DIFF
--- a/app/api/mood/routes.py
+++ b/app/api/mood/routes.py
@@ -1,0 +1,51 @@
+from datetime import date
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_current_user
+from app.core.session import get_db
+from app.db.models import Mood
+from app.utils.response_wrapper import success_response
+
+from .schemas import MoodIn, MoodOut
+
+router = APIRouter(prefix="/mood", tags=["mood"])
+
+
+@router.post("/", response_model=MoodOut)
+async def log_mood(
+    data: MoodIn,
+    db: Session = Depends(get_db),  # noqa: B008
+    user=Depends(get_current_user),  # noqa: B008
+):
+    record = db.query(Mood).filter_by(user_id=user.id, date=data.date).first()
+    if record:
+        record.mood = data.mood
+    else:
+        record = Mood(user_id=user.id, date=data.date, mood=data.mood)
+        db.add(record)
+    db.commit()
+    db.refresh(record)
+    return success_response(
+        {"id": str(record.id), "date": record.date, "mood": record.mood}
+    )
+
+
+@router.get("/", response_model=List[MoodOut])
+async def list_moods(
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    db: Session = Depends(get_db),  # noqa: B008
+    user=Depends(get_current_user),  # noqa: B008
+):
+    query = db.query(Mood).filter(Mood.user_id == user.id)
+    if start_date:
+        query = query.filter(Mood.date >= start_date)
+    if end_date:
+        query = query.filter(Mood.date <= end_date)
+    records = query.order_by(Mood.date).all()
+    return success_response(
+        [{"id": str(r.id), "date": r.date, "mood": r.mood} for r in records]
+    )

--- a/app/api/mood/schemas.py
+++ b/app/api/mood/schemas.py
@@ -1,0 +1,13 @@
+from datetime import date
+from pydantic import BaseModel
+
+
+class MoodIn(BaseModel):
+    date: date
+    mood: str
+
+
+class MoodOut(BaseModel):
+    id: str
+    date: date
+    mood: str

--- a/app/api/notifications/routes.py
+++ b/app/api/notifications/routes.py
@@ -4,9 +4,10 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_current_user
 from app.core.session import get_db
 from app.db.models import PushToken
-from app.services.push_service import send_push_notification
+from app.services.push_service import send_push_notification, send_apns_notification
 from app.utils.email_utils import send_reminder_email
 from app.utils.response_wrapper import success_response
+from app.services.notification_log_service import log_notification
 
 from .schemas import NotificationTest, TokenIn
 
@@ -19,7 +20,7 @@ async def register_token(
     db: Session = Depends(get_db),  # noqa: B008
     user=Depends(get_current_user),  # noqa: B008
 ):
-    token = PushToken(user_id=user.id, token=data.token)
+    token = PushToken(user_id=user.id, token=data.token, platform=data.platform)
     db.add(token)
     db.commit()
     db.refresh(token)
@@ -33,6 +34,7 @@ async def send_test_notification(
     user=Depends(get_current_user),  # noqa: B008
 ):
     token = payload.token
+    platform = payload.platform
     if not token:
         record = (
             db.query(PushToken)
@@ -40,15 +42,28 @@ async def send_test_notification(
             .order_by(PushToken.created_at.desc())
             .first()
         )
-        token = record.token if record else None
+        if record:
+            token = record.token
+            platform = record.platform
 
     if token:
         try:
-            send_push_notification(
-                user_id=user.id, message=payload.message, token=token, db=db
-            )
+            if platform == "apns":
+                send_apns_notification(
+                    user_id=user.id, message=payload.message, token=token, db=db
+                )
+            else:
+                send_push_notification(
+                    user_id=user.id, message=payload.message, token=token, db=db
+                )
         except Exception:
-            pass
+            log_notification(
+                db,
+                user_id=user.id,
+                channel=platform or "push",
+                message=payload.message,
+                success=False,
+            )
 
     email = payload.email or user.email
     try:

--- a/app/api/notifications/schemas.py
+++ b/app/api/notifications/schemas.py
@@ -2,8 +2,10 @@ from pydantic import BaseModel, EmailStr
 
 class TokenIn(BaseModel):
     token: str
+    platform: str = "fcm"
 
 class NotificationTest(BaseModel):
     message: str
     token: str | None = None
     email: EmailStr | None = None
+    platform: str | None = None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -50,6 +50,13 @@ class Settings(BaseSettings):
     smtp_password: str = ""
     smtp_from: str = "no-reply@example.com"
 
+    # APNs settings
+    apns_key: str = ""
+    apns_key_id: str = ""
+    apns_team_id: str = ""
+    apns_topic: str = ""
+    apns_use_sandbox: bool = False
+
     # CORS
     # Restrict to production front-end domain(s) by default
     allowed_origins: list[str] = ["https://app.mita.finance"]

--- a/app/db/models/push_token.py
+++ b/app/db/models/push_token.py
@@ -11,4 +11,5 @@ class PushToken(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id = Column(UUID(as_uuid=True), nullable=False, index=True)
     token = Column(String, nullable=False, unique=True)
+    platform = Column(String, nullable=False, default="fcm")
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,7 @@ from app.api.referral.routes import router as referral_router
 from app.api.spend.routes import router as spend_router
 from app.api.style.routes import router as style_router
 from app.api.insights.routes import router as insights_router
+from app.api.mood.routes import router as mood_router
 from app.api.transactions.routes import router as transactions_router
 from app.api.users.routes import router as users_router
 from app.core.config import settings
@@ -122,6 +123,7 @@ private_routers_list = [
     (transactions_router, "/api/transactions", ["Transactions"]),
     (iap_router, "/api/iap", ["IAP"]),
     (notifications_router, "/api/notifications", ["Notifications"]),
+    (mood_router, "/api/mood", ["Mood"]),
     (referral_router, "/api/referrals", ["Referrals"]),
     (onboarding_router, "/api/onboarding", ["Onboarding"]),
     (cohort_router, "/api/cohorts", ["Cohorts"]),

--- a/app/services/push_service.py
+++ b/app/services/push_service.py
@@ -3,6 +3,9 @@ from typing import Optional
 import firebase_admin
 from firebase_admin import credentials, messaging
 from sqlalchemy.orm import Session
+from apns2.client import APNsClient
+from apns2.payload import Payload
+from app.core.config import settings
 
 if not firebase_admin._apps:
     try:
@@ -49,3 +52,26 @@ def send_push_notification(
             db, user_id=user_id, channel="push", message=message, success=True
         )
     return {"message_id": resp}
+
+
+def send_apns_notification(
+    *,
+    user_id: int,
+    message: str,
+    token: str,
+    db: Optional[Session] = None,
+) -> dict:
+    """Send a push notification via Apple Push Notification service."""
+    client = APNsClient(
+        credentials=settings.apns_key,
+        use_sandbox=settings.apns_use_sandbox,
+        team_id=settings.apns_team_id,
+        key_id=settings.apns_key_id,
+    )
+    payload = Payload(alert=message, sound="default")
+    resp = client.send_notification(token, payload, topic=settings.apns_topic)
+    if db:
+        from app.services.notification_log_service import log_notification
+
+        log_notification(db, user_id=user_id, channel="apns", message=message, success=True)
+    return {"apns_id": resp}

--- a/app/tests/test_mood_routes.py
+++ b/app/tests/test_mood_routes.py
@@ -1,0 +1,73 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.mood.routes import log_mood, list_moods
+from app.api.mood.schemas import MoodIn
+from app.db.models import Mood
+
+
+class DummyDB:
+    def __init__(self, record=None):
+        self.added = []
+        self.committed = False
+        self.refreshed = []
+        self.record = record
+        self.queries = []
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, obj):
+        self.refreshed.append(obj)
+
+    def query(self, model):
+        assert model is Mood
+        self.queries.append(model)
+        return self
+
+    def filter_by(self, **kwargs):
+        self.filter_kwargs = kwargs
+        return self
+
+    def filter(self, *args):
+        return self
+
+    def order_by(self, *args):
+        return self
+
+    def all(self):
+        return [self.record] if self.record else []
+
+    def first(self):
+        return self.record
+
+
+def parse_json(response):
+    return json.loads(response.body.decode())
+
+
+@pytest.mark.asyncio
+async def test_log_mood_creates(monkeypatch):
+    db = DummyDB()
+    user = SimpleNamespace(id="u1")
+    monkeypatch.setattr("app.api.mood.routes.Mood", Mood)
+    resp = await log_mood(MoodIn(date="2025-01-01", mood="happy"), db=db, user=user)
+    data = parse_json(resp)
+    assert db.committed
+    assert db.added
+    assert data["data"]["mood"] == "happy"
+
+
+@pytest.mark.asyncio
+async def test_list_moods(monkeypatch):
+    record = SimpleNamespace(id="m1", date="2025-01-01", mood="sad")
+    db = DummyDB(record)
+    user = SimpleNamespace(id="u1")
+    resp = await list_moods(db=db, user=user)
+    data = parse_json(resp)
+    assert data["data"][0]["mood"] == "sad"

--- a/app/tests/test_notification_routes.py
+++ b/app/tests/test_notification_routes.py
@@ -47,10 +47,11 @@ class DummyDB:
 
 
 class DummyToken:
-    def __init__(self, user_id, token):
+    def __init__(self, user_id, token, platform="fcm"):
         self.id = "t123"
         self.user_id = user_id
         self.token = token
+        self.platform = platform
         self.created_at = None
 
 
@@ -67,7 +68,7 @@ async def test_register_token(monkeypatch):
     db = DummyDB()
     user = SimpleNamespace(id="u1")
 
-    resp = await register_token(TokenIn(token="abc"), db=db, user=user)
+    resp = await register_token(TokenIn(token="abc", platform="fcm"), db=db, user=user)
     payload = parse_json(resp)
 
     assert db.committed
@@ -98,7 +99,7 @@ async def test_send_test_notification(monkeypatch):
     user = SimpleNamespace(id="u1", email="u@example.com")
 
     resp = await send_test_notification(
-        NotificationTest(message="hi", token="tok", email="e@mail.com"),
+        NotificationTest(message="hi", token="tok", email="e@mail.com", platform="fcm"),
         db=db,
         user=user,
     )
@@ -110,7 +111,7 @@ async def test_send_test_notification(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_test_notification_fetches_token(monkeypatch):
-    record = DummyToken("u1", "dbtoken")
+    record = DummyToken("u1", "dbtoken", "fcm")
     db = DummyDB(record)
     user = SimpleNamespace(id="u1", email="u@example.com")
     sent = {}

--- a/migrations/versions/0005_push_token_platform.py
+++ b/migrations/versions/0005_push_token_platform.py
@@ -1,0 +1,26 @@
+"""add platform column to push tokens
+
+Revision ID: 0005_push_token_platform
+Revises: 0004_user_timezone
+Create Date: 2025-09-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0005_push_token_platform"
+down_revision = "0004_user_timezone"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "push_tokens",
+        sa.Column("platform", sa.String(), nullable=False, server_default="fcm"),
+    )
+
+
+def downgrade():
+    op.drop_column("push_tokens", "platform")

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ openai
 boto3
 rq
 rq-scheduler
+apns2


### PR DESCRIPTION
## Summary
- add platform column to `PushToken`
- handle APNs tokens and logging in notification routes
- support Apple push notifications in `push_service`
- add simple mood logging API and tests
- include APNs settings in configuration
- install `apns2` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AttributeError: module 'collections' has no attribute 'MutableMapping')*

------
https://chatgpt.com/codex/tasks/task_e_6853c5b890408322a1420ee5c9452732