### PR TITLE
Add composite index and slow-query helper

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -94,6 +94,7 @@ async def security_headers(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Content-Security-Policy"] = "default-src 'self'"
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=()"
     return response
 
 

--- a/app/tests/test_security_headers.py
+++ b/app/tests/test_security_headers.py
@@ -46,6 +46,7 @@ def test_security_headers_present():
     assert r.headers.get("X-Content-Type-Options") == "nosniff"
     assert r.headers.get("X-Frame-Options") == "DENY"
     assert "default-src" in r.headers.get("Content-Security-Policy", "")
+    assert r.headers.get("Permissions-Policy") == "geolocation=(), microphone=()"
 
 
 def test_cors_restricted():

--- a/migrations/versions/0006_transactions_user_created_at_idx.py
+++ b/migrations/versions/0006_transactions_user_created_at_idx.py
@@ -1,0 +1,27 @@
+"""add composite index for transactions user_id, created_at
+
+Revision ID: 0006_transactions_user_created_at_idx
+Revises: 0005_push_token_platform
+Create Date: 2025-10-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006_transactions_user_created_at_idx"
+down_revision = "0005_push_token_platform"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_transactions_user_created_at",
+        "transactions",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_transactions_user_created_at", table_name="transactions")

--- a/scripts/explain_slow_queries.py
+++ b/scripts/explain_slow_queries.py
@@ -1,0 +1,31 @@
+import os
+import psycopg2
+
+
+def explain_slow_queries(limit: int = 10) -> None:
+    """Print slow queries ordered by total time using pg_stat_statements."""
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+
+    query = (
+        "SELECT query, total_time, calls "
+        "FROM pg_stat_statements "
+        "ORDER BY total_time DESC "
+        "LIMIT %s;"
+    )
+
+    conn = psycopg2.connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(query, (limit,))
+            rows = cur.fetchall()
+            for i, row in enumerate(rows, 1):
+                print(f"{i}. {row[0][:100]}\n   total_time={row[1]:.2f}s calls={row[2]}")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    limit_env = os.getenv("TOP_N", "10")
+    explain_slow_queries(int(limit_env))


### PR DESCRIPTION
## Summary
- add migrations/0006 to create `ix_transactions_user_created_at`
- expose helper script to print slow queries using `pg_stat_statements`
- set `Permissions-Policy` header in FastAPI
- test new response header

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599f55f258832293408455d51c3f89