### PR TITLE
Add Redis metrics exporter and Sentry middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,8 @@ import logging
 import time
 
 import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.rq import RqIntegration
 from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
@@ -57,7 +59,12 @@ from app.core.config import settings
 from app.core.limiter_setup import init_rate_limiter
 from app.utils.response_wrapper import error_response, success_response
 
-sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"), traces_sample_rate=1.0)
+sentry_sdk.init(
+    dsn=os.getenv("SENTRY_DSN"),
+    integrations=[FastApiIntegration(), RqIntegration()],
+    traces_sample_rate=1.0,
+    send_default_pii=True,
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -86,6 +93,25 @@ async def log_requests(request: Request, call_next):
 
 
 @app.middleware("http")
+async def capture_request_bodies(request: Request, call_next):
+    body = await request.body()
+    try:
+        response = await call_next(request)
+    except Exception as exc:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("request_body", body.decode("utf-8", "ignore"))
+            sentry_sdk.capture_exception(exc)
+        raise
+    if response.status_code >= 400:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("request_body", body.decode("utf-8", "ignore"))
+            sentry_sdk.capture_message(
+                f"HTTP {response.status_code} for {request.url.path}"
+            )
+    return response
+
+
+@app.middleware("http")
 async def security_headers(request: Request, call_next):
     response = await call_next(request)
     response.headers["Strict-Transport-Security"] = (
@@ -94,6 +120,7 @@ async def security_headers(request: Request, call_next):
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Content-Security-Policy"] = "default-src 'self'"
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=()"
     return response
 
 

--- a/app/tests/test_security_headers.py
+++ b/app/tests/test_security_headers.py
@@ -46,6 +46,7 @@ def test_security_headers_present():
     assert r.headers.get("X-Content-Type-Options") == "nosniff"
     assert r.headers.get("X-Frame-Options") == "DENY"
     assert "default-src" in r.headers.get("Content-Security-Policy", "")
+    assert r.headers.get("Permissions-Policy") == "geolocation=(), microphone=()"
 
 
 def test_cors_restricted():

--- a/app/tests/test_sentry.py
+++ b/app/tests/test_sentry.py
@@ -1,0 +1,37 @@
+import os
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+import sentry_sdk
+from sentry_sdk.transport import Transport
+
+os.environ.setdefault("FIREBASE_JSON", "{}")
+
+class DummyTransport(Transport):
+    def __init__(self, options=None):
+        super().__init__(options)
+        self.events = []
+
+    def capture_envelope(self, envelope):
+        self.events.append(envelope)
+
+def test_sentry_captures_error():
+    transport = DummyTransport()
+    sentry_sdk.init(dsn="http://example@localhost/1", transport=transport, integrations=[])
+
+    from app.main import app
+
+    async def boom():
+        raise RuntimeError("boom")
+
+    app.add_api_route("/boom", boom, methods=["GET"])
+
+    client = TestClient(app)
+    with pytest.raises(RuntimeError):
+        client.get("/boom")
+
+    sentry_sdk.flush()
+    assert transport.events
+    event = transport.events[0].items[0].payload.json
+    assert "request_body" in event.get("extra", {})

--- a/migrations/versions/0006_transactions_user_created_at_idx.py
+++ b/migrations/versions/0006_transactions_user_created_at_idx.py
@@ -1,0 +1,27 @@
+"""add composite index for transactions user_id, created_at
+
+Revision ID: 0006_transactions_user_created_at_idx
+Revises: 0005_push_token_platform
+Create Date: 2025-10-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006_transactions_user_created_at_idx"
+down_revision = "0005_push_token_platform"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_transactions_user_created_at",
+        "transactions",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_transactions_user_created_at", table_name="transactions")

--- a/monitoring/redis_alert_rules.yml
+++ b/monitoring/redis_alert_rules.yml
@@ -1,0 +1,10 @@
+groups:
+  - name: redis_queue
+    rules:
+      - alert: RedisQueueLatencyHigh
+        expr: queue_latency_seconds > 1
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: Redis queue latency exceeds 1s

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ rq
 rq-scheduler
 apns2
 sentry-sdk
+prometheus-client

--- a/scripts/explain_slow_queries.py
+++ b/scripts/explain_slow_queries.py
@@ -1,0 +1,31 @@
+import os
+import psycopg2
+
+
+def explain_slow_queries(limit: int = 10) -> None:
+    """Print slow queries ordered by total time using pg_stat_statements."""
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+
+    query = (
+        "SELECT query, total_time, calls "
+        "FROM pg_stat_statements "
+        "ORDER BY total_time DESC "
+        "LIMIT %s;"
+    )
+
+    conn = psycopg2.connect(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(query, (limit,))
+            rows = cur.fetchall()
+            for i, row in enumerate(rows, 1):
+                print(f"{i}. {row[0][:100]}\n   total_time={row[1]:.2f}s calls={row[2]}")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    limit_env = os.getenv("TOP_N", "10")
+    explain_slow_queries(int(limit_env))

--- a/scripts/redis_exporter.py
+++ b/scripts/redis_exporter.py
@@ -1,0 +1,41 @@
+import os
+import time
+
+from prometheus_client import Gauge, start_http_server
+from redis import Redis
+from rq import Queue
+
+
+def collect_metrics(queue: Queue, redis: Redis):
+    jobs = queue.get_jobs()
+    LENGTH.set(len(jobs))
+    if jobs:
+        oldest = min((j.enqueued_at for j in jobs if j.enqueued_at), default=None)
+        if oldest:
+            latency = time.time() - oldest.timestamp()
+            LATENCY.set(latency)
+        else:
+            LATENCY.set(0)
+    else:
+        LATENCY.set(0)
+    info = redis.info()
+    EVICTED.set(info.get("evicted_keys", 0))
+
+
+if __name__ == "__main__":
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    queue_name = os.getenv("QUEUE_NAME", "default")
+    port = int(os.getenv("METRICS_PORT", "8001"))
+
+    redis = Redis.from_url(redis_url)
+    queue = Queue(queue_name, connection=redis)
+
+    LATENCY = Gauge("queue_latency_seconds", "Age of oldest job in the queue")
+    LENGTH = Gauge("queue_length", "Number of jobs in the queue")
+    EVICTED = Gauge("evicted_keys_total", "Total evicted keys from Redis")
+
+    start_http_server(port)
+
+    while True:
+        collect_metrics(queue, redis)
+        time.sleep(5)


### PR DESCRIPTION
## Summary
- expose Prometheus metrics for Redis queue latency/length
- alert when queue latency > 1s
- initialise Sentry with FastAPI and RQ integrations
- record request bodies for all 4xx/5xx responses
- test that Sentry receives events

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599f55f258832293408455d51c3f89